### PR TITLE
add missing .py to README

### DIFF
--- a/hyperbolic-rs/README.md
+++ b/hyperbolic-rs/README.md
@@ -68,7 +68,7 @@ The output of this script will be the "prep file" and it will be stored in
 ### 4. Train model
 The name of the preprocessing used in the previous step must be given as a parameter.
 ```
-python train --prep_name=amzn-musicins --run_id=my_trained_model
+python train.py --prep_name=amzn-musicins --run_id=my_trained_model
 ```
 
 More parameters can be set on the ``config.py`` file.


### PR DESCRIPTION
Added missing `.py` to the README for the training command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pair-code/recommendation-rudders/9)
<!-- Reviewable:end -->
