### PR TITLE
Support `/api/llm` calls for LLM prediction and plumb through the Palm2ApiParams for it.

### DIFF
--- a/llm-recs/appengine-server/server.ts
+++ b/llm-recs/appengine-server/server.ts
@@ -27,21 +27,6 @@ interface SimpleLLMRequest {
   modelId: string;
 }
 
-interface Palm2ApiOptions {
-  modelId: string,
-  apiEndpoint: string,
-  requestParameters: Palm2ApiParams
-}
-
-interface Palm2ApiParams {
-  candidateCount: number, // 1 to 8
-  maxOutputTokens: number, // 256, 1024
-  stopSequences: string[], // e.g. ']
-  temperature: number,  // e.g. 0.2 (0=deterministic, 1=wild, x>1=crazy)
-  topP: number,  // e.g. 0.8 (0-1, smaller = restricts crazyiness)
-  topK: number  // e.g. 40 (0-numOfTokens, smaller = restricts crazyiness)
-}
-
 async function main() {
 
   const auth = new GoogleAuth({
@@ -76,6 +61,8 @@ async function main() {
 
   app.post('/api/llm', async (req: Request, res: Response) => {
     const request = (req.body as SimpleLLMRequest)
+    // TODO: we now have duplicated definitions of default options, we might want to
+    // remove one of them.
     const options = {
       modelId: request.modelId || 'text-bison',
       apiEndpoint: 'us-central1-aiplatform.googleapis.com',
@@ -87,7 +74,7 @@ async function main() {
         maxOutputTokens: 256,
         stopSequences: [],
       }
-    } as Palm2ApiOptions;
+    };
     const llm = new VertexPalm2LLM(
       projectId,
       client,

--- a/llm-recs/appengine-server/src/text-templates/llm_gaxois_vertexapi_palm2.ts
+++ b/llm-recs/appengine-server/src/text-templates/llm_gaxois_vertexapi_palm2.ts
@@ -125,33 +125,35 @@ interface Palm2ApiOptions {
 
 export class VertexPalm2LLM implements LLM<Palm2ApiOptions> {
   public name: string;
-  public defaultOptions: Palm2ApiOptions = {
-    modelId: 'text-bison',
-    apiEndpoint: 'us-central1-aiplatform.googleapis.com',
-    requestParameters: {
-      temperature: 0.7,
-      topK: 40,
-      topP: 0.95,
-      candidateCount: 4,
-      maxOutputTokens: 256,
-      stopSequences: [],
-    }
-  };
+  public options: Palm2ApiOptions;
 
   constructor(
     public projectId: string,
     public client: AuthClient,
+    public params?: Palm2ApiOptions,
   ) {
-    this.name = `VertexLLM:` + this.defaultOptions.modelId;
+    const defaultOptions = {
+      modelId: 'text-bison',
+      apiEndpoint: 'us-central1-aiplatform.googleapis.com',
+      requestParameters: {
+        temperature: 0.7,
+        topK: 40,
+        topP: 0.95,
+        candidateCount: 4,
+        maxOutputTokens: 256,
+        stopSequences: [],
+      }
+    } as Palm2ApiOptions;
+    this.options = params ? params : defaultOptions;
+    this.name = `VertexLLM:` + this.options.modelId;
   }
 
-  //
   async predict(
     query: string, params?: Palm2ApiOptions
   ): Promise<PredictResponse> {
 
     const apiParams = params ? params.requestParameters
-      : this.defaultOptions.requestParameters;
+      : this.options.requestParameters;
     const apiRequest: Palm2ApiRequest = {
       instances: [{ content: query }],
       parameters: apiParams
@@ -161,8 +163,8 @@ export class VertexPalm2LLM implements LLM<Palm2ApiOptions> {
       this.projectId,
       this.client,
       apiRequest,
-      this.defaultOptions.modelId,
-      this.defaultOptions.apiEndpoint);
+      this.options.modelId,
+      this.options.apiEndpoint);
 
     // The API doesn't include the actual stop sequence that it found, so we
     // can never know the true stop seqeunce, so we just pick the first one,

--- a/llm-recs/llm-recs-webclient/src/app/lm-api.service.ts
+++ b/llm-recs/llm-recs-webclient/src/app/lm-api.service.ts
@@ -9,6 +9,7 @@
 import { Injectable } from '@angular/core';
 // import { VertexPalm2LLM } from '../lib/text-templates/llm_vertexapi_palm2';
 import { SimpleEmbedder } from 'src/lib/text-embeddings/embedder_api';
+import { SimpleLlm } from 'src/lib/text-templates/llm_api';
 
 // TODO: Unclear to me if this is needed or helpful...
 //
@@ -18,10 +19,11 @@ import { SimpleEmbedder } from 'src/lib/text-embeddings/embedder_api';
   providedIn: 'root'
 })
 export class LmApiService {
-  // public llm: VertexPalm2LLM;
+  public llm: SimpleLlm;
   public embedder: SimpleEmbedder;
 
   constructor() {
     this.embedder = new SimpleEmbedder();
+    this.llm = new SimpleLlm();
   }
 }

--- a/llm-recs/llm-recs-webclient/src/lib/text-templates/llm_api.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-templates/llm_api.ts
@@ -1,0 +1,49 @@
+/*==============================================================================
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an Apache2 license that can be
+ * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
+==============================================================================*/
+
+/*
+An class to wrap, and provide a common interface for LLM behaviour.
+*/
+import { LLM, PredictResponse } from "./llm";
+import { Palm2ApiOptions, Palm2ApiParams } from "./llm_vertexapi_palm2";
+
+interface LlmRequest {
+  text: string
+  params?: Palm2ApiOptions
+}
+
+async function sendLlmRequest(request: LlmRequest): Promise<PredictResponse> {
+  // Default options are marked with *
+  const response = await fetch(`/api/llm`, {
+    method: 'POST', // *GET, POST, PUT, DELETE, etc.
+    mode: 'cors', // no-cors, *cors, same-origin
+    cache: 'no-cache', // *default, no-cache, reload, force-cache, only-if-cached
+    credentials: 'same-origin', // include, *same-origin, omit
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    redirect: 'follow', // manual, *follow, error
+    referrerPolicy: 'no-referrer', // no-referrer, *no-referrer-when-downgrade, origin, origin-when-cross-origin, same-origin, strict-origin, strict-origin-when-cross-origin, unsafe-url
+    body: JSON.stringify(request), // body data type must match "Content-Type" header
+  });
+  console.log(response);
+  return (await response.json() as PredictResponse); // parses JSON response into native JavaScript objects
+}
+
+export class SimpleLlm implements LLM<{}> {
+  public name: string;
+  constructor() {
+    this.name = `SimpleLlm`
+  }
+  async predict(
+    text: string, params?: Palm2ApiOptions
+  ): Promise<PredictResponse> {
+    const apiResponse = await sendLlmRequest({ text, params });
+    return apiResponse
+  }
+}

--- a/llm-recs/llm-recs-webclient/src/lib/text-templates/llm_vertexapi_palm2.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-templates/llm_vertexapi_palm2.ts
@@ -107,7 +107,7 @@ export async function sendPalm2Request(
   // .catch((err) => console.error(err));
 }
 
-interface Palm2ApiOptions {
+export interface Palm2ApiOptions {
   modelId: string,
   apiEndpoint: string,
   requestParameters: Palm2ApiParams


### PR DESCRIPTION
- server provides llm API from POST queries to `/api/llm`
- allow configuration for temperature and modelId for the Palm2ApiOptions