### PR TITLE
allow datamodel to have titles for items and UI to show keys

### DIFF
--- a/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.html
+++ b/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.html
@@ -3,7 +3,7 @@
 } @else if (mode == 'view') {
 <div class="item">
   <div class="bullet">&#8226;</div>
-  <div class="item-text"><span>{{item.text}}</span></div>
+  <div class="item-text"><span class="title">{{item.title}}</span>. <span class="text">{{item.text}}</span></div>
   <button class="small-icon-button hoverBtn" mat-icon-button aria-label="Edit" (click)="editMode()">
     <mat-icon>edit</mat-icon>
   </button>
@@ -18,14 +18,30 @@
 } @else {
   <div>
   <form class="edit-form" (submit)="save()">
-    <mat-form-field class="full-width">
+    <mat-form-field class="full-width title-input">
+      <mat-label>Item Title</mat-label>
+      <input matInput [formControl]="itemTitleControl">
+    </mat-form-field>
+    <mat-form-field class="full-width text-input">
       <mat-label>Item Text</mat-label>
       <textarea matInput [formControl]="itemTextControl"></textarea>
     </mat-form-field>
+    @for (key of keys; track $index) {
+      <mat-form-field class="full-width key-input">
+        <mat-label>Key</mat-label>
+        <input matInput [formControl]="keyControls[$index]">
+      </mat-form-field>
+    }
     <mat-progress-bar *ngIf="waiting" [mode]="'indeterminate'"></mat-progress-bar>
     <div class='error' *ngIf="saveError">{{saveError}}</div>
 
     <div class="view-header">
+      <button type="button" mat-button aria-label="add key" (click)="addKey()">
+        <mat-icon>add</mat-icon> add key
+      </button>
+      <button color="primary" type="submit" mat-flat-button aria-label="Edit">
+        save
+      </button>
       <button type="button" mat-icon-button aria-label="More actions" [matMenuTriggerFor]="menu">
         <mat-icon>more_vert</mat-icon>
       </button>
@@ -34,9 +50,6 @@
         <button mat-menu-item (click)="revert()">Revert</button>
         <button mat-menu-item (click)="viewMode()">Cancel</button>
       </mat-menu>
-      <button color="primary" type="submit" mat-flat-button aria-label="Edit">
-        save
-      </button>
   <!--
       <button class="small-icon-button hoverBtn" mat-icon-button aria-label="Edit" (click)="editMode()">
         <mat-icon>edit</mat-icon>

--- a/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.scss
+++ b/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.scss
@@ -87,10 +87,32 @@
 
 .edit-form {
   margin-bottom: 20px;
+  border: solid 1px #ddd;
+  border-radius: 5px;
 }
 
 .edit-form mat-form-field {
-  margin-bottom: -10px;
+  // margin-bottom: -10px;
+}
+
+.title {
+  font-weight: 800;
+}
+
+.title-input {
+  font-weight: 800;
+}
+
+.text {
+  flex: 1;
+}
+
+.text-input {
+  font-size: small;
+}
+
+.key-input {
+  font-size: small;
 }
 
 .item {

--- a/llm-recs/llm-recs-webclient/src/app/data-viewer/data-viewer.component.html
+++ b/llm-recs/llm-recs-webclient/src/app/data-viewer/data-viewer.component.html
@@ -1,15 +1,17 @@
 <div class="main">
 
   <div class="infoBar">
-    <div class="searchBlock" *ngIf="search && search()">
-      Sort by:
-      <div class="searchChip">
-        <span>{{search()?.text}}</span>
-        <button class="small-icon-button" mat-icon-button aria-label="Remove search" (click)="removeSearch()">
-          <mat-icon>close</mat-icon>
-        </button>
+    @if (search && search()) {
+      <div class="searchBlock">
+        Sort by:
+        <div class="searchChip">
+          <span>{{search()!.query}}</span>
+          <button class="small-icon-button" mat-icon-button aria-label="Remove search" (click)="removeSearch()">
+            <mat-icon>close</mat-icon>
+          </button>
+        </div>
       </div>
-    </div>
+    }
     <div class="spacer"></div>
     <div class="itemsCount">[<span>{{size()}}</span> items]</div>
   </div>

--- a/llm-recs/llm-recs-webclient/src/app/data-viewer/data-viewer.component.ts
+++ b/llm-recs/llm-recs-webclient/src/app/data-viewer/data-viewer.component.ts
@@ -11,7 +11,7 @@ import { DataItem, SavedDataService } from '../saved-data.service';
 // import { EventEmitter, Input, OnInit, Output, effect } from '@angular/core';
 
 export interface SearchSpec {
-  text: string;
+  query: string;
   embedding: number[];
 }
 

--- a/llm-recs/llm-recs-webclient/src/app/item-interpreter.service.spec.ts
+++ b/llm-recs/llm-recs-webclient/src/app/item-interpreter.service.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an Apache2 license that can be
+ * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
+==============================================================================*/
+
+import { TestBed } from '@angular/core/testing';
+
+import { ItemInterpreterService } from './item-interpreter.service';
+
+describe('ItemInterpreterService', () => {
+  let service: ItemInterpreterService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ItemInterpreterService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/llm-recs/llm-recs-webclient/src/app/item-interpreter.service.ts
+++ b/llm-recs/llm-recs-webclient/src/app/item-interpreter.service.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an Apache2 license that can be
+ * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
+==============================================================================*/
+
+import { Injectable } from '@angular/core';
+import { LmApiService } from './lm-api.service';
+
+export interface InterpretedItem {
+  title: string;
+  text: string;
+  keys: string[];
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ItemInterpreterService {
+
+  constructor(
+    // TODO: use this with a prompt to do smarter interpretation.
+    private lmApiService: LmApiService,
+    // public interpretationPrompt: Template<input, title, keys>
+  ) { }
+
+  interpretItemText(text: string): InterpretedItem {
+    const title = text.slice(0, 20);
+    const keys = [... new Set<string>(text.split('.'))];
+    return { title, text, keys };
+  }
+}

--- a/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder.ts
@@ -8,7 +8,7 @@ export interface EmbedError {
 
 export type EmbedResponse = Embedding | EmbedError;
 
-export function isEmbedError(response: EmbedResponse): response is EmbedError {
+export function isEmbedError<T>(response: T | EmbedError): response is EmbedError {
   if ((response as EmbedError).error) {
     return true;
   }


### PR DESCRIPTION
 * Adds titles to the datamodel for items. 
 * Shows keys for items in the edit item view (and allows adding more)
 * Introduces an interpreter service that takes text and produces items and keys. (to be swapped with an LLM call)
 * Moves more work into the data service the add item method (it now does embedding lookups too)