### PR TITLE
Change the interpreter service to call the LLM service.

### DIFF
--- a/llm-recs/llm-recs-webclient/src/app/saved-data.service.ts
+++ b/llm-recs/llm-recs-webclient/src/app/saved-data.service.ts
@@ -126,7 +126,7 @@ export class SavedDataService {
     if (!text) {
       return { error: 'Cannot add empty text!' };
     }
-    const item = this.itemInterpreterService.interpretItemText(text);
+    const item = await this.itemInterpreterService.interpretItemText(text);
     const embeddings = {} as ItemEmbeddings;
     for (const key of item.keys) {
       if (key.trim() === '') {


### PR DESCRIPTION
* Replaces the item-interpreter hack with an LLM call. 

To followup: 
* Better error handling for end-user to see errors (and also to still save something, even if LLM/parsing fails)
* Add UI to see/swap between multiple interpretations? Or is one always enough?
* Better parsing code for the few-shot-template list of characteristics. 