### PR TITLE
UI improvements and template code improvements (and few short parsing)

### DIFF
--- a/llm-recs/appengine-server/server.ts
+++ b/llm-recs/appengine-server/server.ts
@@ -9,7 +9,7 @@
 import express, { Express, Request, Response } from 'express';
 import { GoogleAuth } from 'google-auth-library';
 import { VertexEmbedder } from './src/text-embeddings/embedder_gaxois_vertexapi';
-import { VertexPalm2LLM } from './src/text-templates/llm_gaxois_vertexapi_palm2';
+import { VertexPalm2LLM, Palm2ApiOptions, Palm2ApiParams } from './src/text-templates/llm_gaxois_vertexapi_palm2';
 import * as path from 'path';
 
 export const app: Express = express();
@@ -17,14 +17,23 @@ app.use(express.static('./static'));
 app.use(express.json());  // for POST requests
 app.use(express.urlencoded({ extended: true }));  // for PUT requests
 
-interface SimpleEmbedRequest {
-  text: string;
+export interface LlmOptions {
+  modelId?: string; // e.g. text-bison
+  candidateCount?: number, // e.g. 1 to 8 = number of completions
+  maxOutputTokens?: number, // e.g. 256, 1024
+  stopSequences?: string[], // e.g. ']
+  temperature?: number,  // e.g. 0.8 (0=deterministic, 0.7-0.9=normal, x>1=wild)
+  topP?: number,  // e.g. 0.8 (0-1, smaller = restricts crazyiness)
+  topK?: number  // e.g. 40 (0-numOfTokens, smaller = restricts crazyiness)
 }
 
-interface SimpleLLMRequest {
+export interface LlmRequest {
+  text: string
+  params?: LlmOptions
+}
+
+export interface SimpleEmbedRequest {
   text: string;
-  temperature: number;
-  modelId: string;
 }
 
 async function main() {
@@ -42,21 +51,10 @@ async function main() {
 
   const embedder = new VertexEmbedder(client, projectId);
 
-  app.get('/submit', (req: Request, res: Response) => {
-    res.sendFile(path.join(__dirname, '/views/form.html'));
-  });
-
-  app.post('/submit', (req: Request, res: Response) => {
-    console.log({
-      name: req.body.name,
-      message: req.body.message,
-    });
-    res.send('Thanks for your message!');
-  });
-
   app.post('/api/embed', async (req: Request, res: Response) => {
+    console.log(`${new Date()}: /api/embed`);
     const query = (req.body as SimpleEmbedRequest).text
-    if(query.trim() === '') {
+    if (query.trim() === '') {
       return res.send({ error: 'Empty string does not have an embedding.' });
     }
     const embedding = await embedder.embed(query);
@@ -64,20 +62,19 @@ async function main() {
   });
 
   app.post('/api/llm', async (req: Request, res: Response) => {
-    const request = (req.body as SimpleLLMRequest)
+    console.log(`${new Date()}: /api/llm`);
+    const request = (req.body as LlmRequest)
+    // Convert from Simple LlmRequest to VertexAI LLM request.
+    const inputRequestParameters = { ...request.params };
+    delete inputRequestParameters.modelId;
+    const requestParameters = inputRequestParameters as Palm2ApiParams;
+
     // TODO: we now have duplicated definitions of default options, we might want to
     // remove one of them.
-    const options = {
-      modelId: request.modelId || 'text-bison',
+    const options: Palm2ApiOptions = {
+      modelId: (request.params && request.params.modelId) || 'text-bison',
       apiEndpoint: 'us-central1-aiplatform.googleapis.com',
-      requestParameters: {
-        temperature: request.temperature || 0.7,
-        topK: 40,
-        topP: 0.95,
-        candidateCount: 4,
-        maxOutputTokens: 256,
-        stopSequences: [],
-      }
+      requestParameters,
     };
     const llm = new VertexPalm2LLM(
       projectId,

--- a/llm-recs/appengine-server/server.ts
+++ b/llm-recs/appengine-server/server.ts
@@ -64,7 +64,7 @@ async function main() {
   app.post('/api/llm', async (req: Request, res: Response) => {
     console.log(`${new Date()}: /api/llm`);
     const request = (req.body as LlmRequest)
-    // Convert from Simple LlmRequest to VertexAI LLM request.
+    // Convert from LlmRequest to VertexAI LLM request.
     const inputRequestParameters = { ...request.params };
     delete inputRequestParameters.modelId;
     const requestParameters = inputRequestParameters as Palm2ApiParams;

--- a/llm-recs/appengine-server/src/simple-errors/simple-errors.ts
+++ b/llm-recs/appengine-server/src/simple-errors/simple-errors.ts
@@ -1,0 +1,25 @@
+
+export interface AbstractErrorResponse {
+  error: unknown;
+}
+
+export interface ErrorResponse {
+  error: string;
+}
+
+export function isErrorResponse<T, E extends AbstractErrorResponse>(
+  response: T | E
+): response is E {
+  if ((response as E).error) {
+    return true;
+  }
+  return false;
+}
+
+export function assertNoErrorResponse<T, E extends AbstractErrorResponse>(
+  response: T | E
+): asserts response is T {
+  if ((response as E).error) {
+    throw new Error('response was an error after all');
+  }
+}

--- a/llm-recs/appengine-server/src/text-templates/llm_gaxois_vertexapi_palm2.ts
+++ b/llm-recs/appengine-server/src/text-templates/llm_gaxois_vertexapi_palm2.ts
@@ -143,21 +143,21 @@ function overideOptions(
 
 export class VertexPalm2LLM implements LLM<Palm2ApiOptions> {
   public name: string;
-  public defaultOptions: Palm2ApiOptions;
+  public ptions: Palm2ApiOptions;
 
   constructor(
     public projectId: string,
     public client: AuthClient,
     public initOptions?: Partial<Palm2ApiOptions>,
   ) {
-    this.defaultOptions = overideOptions(DEFAULT_OPTIONS, initOptions);
-    this.name = `VertexLLM:` + this.defaultOptions.modelId;
+    this.ptions = overideOptions(DEFAULT_OPTIONS, initOptions);
+    this.name = `VertexLLM:` + this.ptions.modelId;
   }
 
   async predict(
     query: string, options?: Palm2ApiOptions
   ): Promise<PredictResponse> {
-    const usedOptions = overideOptions(this.defaultOptions, options);
+    const usedOptions = overideOptions(this.ptions, options);
     const apiRequest: Palm2ApiRequest = {
       instances: [{ content: query }],
       parameters: usedOptions.requestParameters
@@ -167,8 +167,8 @@ export class VertexPalm2LLM implements LLM<Palm2ApiOptions> {
       this.projectId,
       this.client,
       apiRequest,
-      this.defaultOptions.modelId,
-      this.defaultOptions.apiEndpoint);
+      this.ptions.modelId,
+      this.ptions.apiEndpoint);
 
     // The API doesn't include the actual stop sequence that it found, so we
     // can never know the true stop seqeunce, so we just pick the first one,

--- a/llm-recs/appengine-server/src/text-templates/llm_gaxois_vertexapi_palm2.ts
+++ b/llm-recs/appengine-server/src/text-templates/llm_gaxois_vertexapi_palm2.ts
@@ -14,6 +14,7 @@ See: https://cloud.google.com/vertex-ai/docs/generative-ai/model-reference/text
 
 import { AuthClient } from "google-auth-library";
 import { LLM, PredictResponse } from "./llm";
+import { isErrorResponse } from "../simple-errors/simple-errors";
 
 export interface Palm2ApiParams {
   candidateCount: number, // 1 to 8
@@ -64,27 +65,30 @@ export interface Palm2Error {
   }
 }
 
-function isErrorResponse(response: Palm2Response
-  ): response is Palm2Error {
-    if ((response as Palm2Error).error) {
-      return true;
-    }
-    return false;
-  }
+export const DEFAULT_PARAMS: Palm2ApiParams = {
+  temperature: 0.7,
+  topK: 40,
+  topP: 0.95,
+  candidateCount: 4,
+  maxOutputTokens: 256,
+  stopSequences: [],
+};
+
+export const DEFAULT_OPTIONS: Palm2ApiOptions = {
+  modelId: 'text-bison',
+  apiEndpoint: 'us-central1-aiplatform.googleapis.com',
+  requestParameters: DEFAULT_PARAMS,
+};
 
 export type Palm2Response = Palm2ValidResponse | Palm2Error;
 
-export function preparePalm2Request(text: string, options?: Palm2ApiParams): Palm2ApiRequest {
+export function preparePalm2Request(
+  text: string, params?: Partial<Palm2ApiParams>
+): Palm2ApiRequest {
   return {
     instances: [{ content: text }],
-    parameters: {
-      temperature: (options && options.temperature) || 0.7,
-      topK: (options && options.topK) || 40,
-      topP: (options && options.topP) || 0.95,
-      candidateCount: (options && options.candidateCount) || 4,
-      maxOutputTokens: (options && options.maxOutputTokens) || 256,
-      stopSequences: (options && options.stopSequences) || [],
-    }
+    parameters:
+      (params && Object.assign({ ...DEFAULT_PARAMS }, params)) || DEFAULT_PARAMS
   };
 }
 
@@ -117,64 +121,65 @@ export async function sendPalm2Request(
   );
 }
 
-interface Palm2ApiOptions {
+export interface Palm2ApiOptions {
   modelId: string,
   apiEndpoint: string,
   requestParameters: Palm2ApiParams
 }
 
+// TODO: consider using lodash merge...
+function overideOptions(
+  oldOptions: Palm2ApiOptions,
+  newOptions?: Partial<Palm2ApiOptions>,
+): Palm2ApiOptions {
+  const finalOptions: Palm2ApiOptions = (newOptions &&
+    Object.assign({ ...oldOptions }, newOptions)) || oldOptions;
+  if (newOptions && newOptions.requestParameters) {
+    finalOptions.requestParameters =
+      Object.assign({ ...oldOptions.requestParameters }, newOptions.requestParameters);
+  }
+  return finalOptions;
+}
+
 export class VertexPalm2LLM implements LLM<Palm2ApiOptions> {
   public name: string;
-  public options: Palm2ApiOptions;
+  public defaultOptions: Palm2ApiOptions;
 
   constructor(
     public projectId: string,
     public client: AuthClient,
-    public params?: Palm2ApiOptions,
+    public initOptions?: Partial<Palm2ApiOptions>,
   ) {
-    const defaultOptions = {
-      modelId: 'text-bison',
-      apiEndpoint: 'us-central1-aiplatform.googleapis.com',
-      requestParameters: {
-        temperature: 0.7,
-        topK: 40,
-        topP: 0.95,
-        candidateCount: 4,
-        maxOutputTokens: 256,
-        stopSequences: [],
-      }
-    } as Palm2ApiOptions;
-    this.options = params ? params : defaultOptions;
-    this.name = `VertexLLM:` + this.options.modelId;
+    this.defaultOptions = overideOptions(DEFAULT_OPTIONS, initOptions);
+    this.name = `VertexLLM:` + this.defaultOptions.modelId;
   }
 
   async predict(
-    query: string, params?: Palm2ApiOptions
+    query: string, options?: Palm2ApiOptions
   ): Promise<PredictResponse> {
-
-    const apiParams = params ? params.requestParameters
-      : this.options.requestParameters;
+    const usedOptions = overideOptions(this.defaultOptions, options);
     const apiRequest: Palm2ApiRequest = {
       instances: [{ content: query }],
-      parameters: apiParams
+      parameters: usedOptions.requestParameters
     }
 
     const apiResponse = await sendPalm2Request(
       this.projectId,
       this.client,
       apiRequest,
-      this.options.modelId,
-      this.options.apiEndpoint);
+      this.defaultOptions.modelId,
+      this.defaultOptions.apiEndpoint);
 
     // The API doesn't include the actual stop sequence that it found, so we
     // can never know the true stop seqeunce, so we just pick the first one,
     // and image it is that.
-    const imaginedPostfixStopSeq = apiParams.stopSequences.length > 0 ?
-      apiParams.stopSequences[0] : '';
+    const stopSequences = usedOptions.requestParameters.stopSequences;
+    const imaginedPostfixStopSeq = stopSequences.length > 0 ?
+      stopSequences[0] : '';
 
     if (isErrorResponse(apiResponse)) {
       throw new Error(`Error in api response:` +
-      ` ${JSON.stringify(apiResponse.error, null, 2)}`);
+        ` ${JSON.stringify(apiResponse.error, null, 2)}`);
     }
 
     if (!apiResponse.predictions) {

--- a/llm-recs/llm-recs-webclient/src/app/app-settings/app-settings.component.ts
+++ b/llm-recs/llm-recs-webclient/src/app/app-settings/app-settings.component.ts
@@ -10,11 +10,11 @@ import { Component, ElementRef, OnInit, ViewChild, effect } from '@angular/core'
 import { AppData, SavedDataService } from '../saved-data.service';
 import { FormControl } from '@angular/forms';
 import { LmApiService } from '../lm-api.service';
-import { isEmbedError } from 'src/lib/text-embeddings/embedder';
 import { GoogleSheetsService, isSheetsError } from '../google-sheets.service';
 import { GoogleAuthService } from '../google-auth.service';
 import { GoogleDriveAppdataService } from '../google-drive-appdata.service';
 import { ItemInterpreterService } from '../item-interpreter.service';
+import { ErrorResponse, isErrorResponse } from 'src/lib/simple-errors/simple-errors';
 
 
 @Component({
@@ -131,7 +131,7 @@ export class AppSettingsComponent implements OnInit {
       for (const item of Object.values(uploadedData.items)) {
         if (Object.keys(item.embeddings).length === 0) {
           const embedResult = await this.lmApiService.embedder.embed(item.text);
-          if (isEmbedError(embedResult)) {
+          if (isErrorResponse(embedResult)) {
             if (!this.errorMessage) {
               this.errorMessage = embedResult.error;
             }
@@ -188,7 +188,7 @@ export class AppSettingsComponent implements OnInit {
       }
 
       const result = await this.dataService.createItem(s);
-      if (isEmbedError(result)) {
+      if (isErrorResponse(result)) {
         this.errorMessage = result.error;
         this.errorCount++;
         return;

--- a/llm-recs/llm-recs-webclient/src/app/app-settings/app-settings.component.ts
+++ b/llm-recs/llm-recs-webclient/src/app/app-settings/app-settings.component.ts
@@ -187,12 +187,13 @@ export class AppSettingsComponent implements OnInit {
         break;
       }
 
-      const result = this.dataService.add(s);
+      const result = await this.dataService.createItem(s);
       if (isEmbedError(result)) {
         this.errorMessage = result.error;
         this.errorCount++;
         return;
       }
+      this.dataService.addDataItem(result);
     }
     // if (data.sheets) {
     //   info.sheets.forEach(sheet => {

--- a/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.html
+++ b/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.html
@@ -1,4 +1,5 @@
-@if (!initialDataItem) {
+@if (mode == 'hidden') {
+} @else if (!initialDataItem) {
   <div>No item given to component</div>
 } @else if (mode == 'view') {
 <div class="item">
@@ -6,7 +7,7 @@
   <div class="item-and-characteristics">
     <div class="item-text-parts">
       <div class="item-text-parts-header">
-        <span class="item-title">{{this.dataItem().entityTitle}}</span>.
+        <span class="item-title">{{this.dataItem().entityTitle}}</span>
         <span class="item-details">(<span class="item-details-content">{{this.dataItem().entityDetails.trim()}}</span>)</span>
       </div>
       <div>
@@ -21,7 +22,7 @@
     </div>
   </div>
 
-  <button class="small-icon-button hoverBtn" mat-icon-button aria-label="Edit" (click)="editMode()">
+  <button class="small-icon-button hoverBtn" mat-icon-button aria-label="Edit" (click)="editMode = 'edit'">
     <mat-icon>edit</mat-icon>
   </button>
   <!-- <div class="view-header">
@@ -32,41 +33,43 @@
     <span class="embedding">embed: {{itemEmbeddingStr(item)}}</span>
   </div> -->
 </div>
-
 } @else {
-  <div>
-  <form class="edit-form" (submit)="save()">
-    <mat-form-field class="full-width title-input">
-      <mat-label>Item Title</mat-label>
-      <input matInput [ngModelOptions]="{standalone: true}" [ngModel]="this.dataItem().entityTitle" (ngModelChange)="setTitle($event)">
-    </mat-form-field>
+  <div class="edit-form">
+  <form (submit)="save()">
     <mat-form-field class="full-width text-input">
-      <mat-label>Item Details</mat-label>
-      <textarea matInput [ngModelOptions]="{standalone: true}" [ngModel]="this.dataItem().entityDetails" (ngModelChange)="setDetails($event)"></textarea>
-    </mat-form-field>
-    <mat-form-field class="full-width text-input">
-      <mat-label>Sentiment</mat-label>
-      <textarea matInput [ngModelOptions]="{standalone: true}" [ngModel]="this.dataItem().sentiment" (ngModelChange)="setSentiment($event)"></textarea>
-    </mat-form-field>
-    <mat-form-field class="full-width text-input">
-      <mat-label>Item Text</mat-label>
+      <mat-label>Experience Description</mat-label>
       <textarea matInput [ngModelOptions]="{standalone: true}" [ngModel]="this.dataItem().text" (ngModelChange)="setText($event)"></textarea>
     </mat-form-field>
+    <mat-form-field class="full-width title-input">
+      <mat-label>Title (name of movie, place, etc)</mat-label>
+      <input matInput [ngModelOptions]="{standalone: true}" [ngModel]="this.dataItem().entityTitle" (ngModelChange)="setTitle($event)">
+    </mat-form-field>
+    <mat-form-field class="text-input">
+      <mat-label>Details (e.g. year, director, etc)</mat-label>
+      <input matInput [ngModelOptions]="{standalone: true}" [ngModel]="this.dataItem().entityDetails" (ngModelChange)="setDetails($event)">
+    </mat-form-field>
+    <mat-form-field class="text-input">
+      <mat-label>Liked or Disliked?</mat-label>
+      <input matInput [ngModelOptions]="{standalone: true}" [ngModel]="this.dataItem().sentiment" (ngModelChange)="setSentiment($event)">
+    </mat-form-field>
+    <div class="characteristics-input-list">
     @for (key of keys; track $index) {
-      <mat-form-field class="full-width key-input">
+      <mat-form-field class="key-input">
         <mat-label>Characteristic</mat-label>
         <input matInput [ngModelOptions]="{standalone: true}" [ngModel]="key" (ngModelChange)="keys[$index] = $event">
       </mat-form-field>
     }
+    <button type="button" mat-icon-button aria-label="add key" (click)="addKey()">
+      <mat-icon>add</mat-icon>
+    </button>
+    </div>
     <mat-progress-bar *ngIf="waiting" [mode]="'indeterminate'"></mat-progress-bar>
     <div class='error' *ngIf="saveError">{{saveError}}</div>
 
     <div class="view-header">
-      <button type="button" mat-button aria-label="add key" (click)="addKey()">
-        <mat-icon>add</mat-icon> add key
-      </button>
+      <button (click)="cancelEdit()" type="submit" mat-flat-button aria-label="Cancel">Cancel</button>
       <button color="primary" type="submit" mat-flat-button aria-label="Edit">
-        save
+        Save
       </button>
   <!--
       <button class="small-icon-button hoverBtn" mat-icon-button aria-label="Edit" (click)="editMode()">
@@ -85,7 +88,7 @@
       <mat-menu #menu="matMenu">
         <button mat-menu-item (click)="deleteItem()">Delete</button>
         <button mat-menu-item (click)="revert()">Revert</button>
-        <button mat-menu-item (click)="viewMode()">Cancel</button>
+        <button mat-menu-item (click)="interpretFromText()">Interpret from text</button>
       </mat-menu>
     </div>
   </form>

--- a/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.scss
+++ b/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.scss
@@ -58,16 +58,19 @@
 .item-sentiment {
   display: inline-block;
   margin-right: 5px;
-  padding: 3px;
-  padding-left: 8px;
-  padding-right: 8px;
+  padding: 1px;
+  padding-left: 5px;
+  padding-right: 5px;
   max-width: 20em;
+  text-overflow: ellipsis;
+  overflow: hidden;
   white-space: nowrap;
   font-size: smaller;
-  border-radius: 25px;
-  background-color: #eeeeee;
-  margin-top: 10px;
-  font-weight: 800;
+  // border: 1px solid #ccc;
+  // background-color: #eeeeee;
+  background-color: #ddd;
+  margin-bottom: 10px;
+  // font-weight: 800;
   // display: inline-block;
   // margin-right: 5px;
   // padding: 3px;
@@ -100,7 +103,7 @@
   font-size: smaller;
   border-radius: 25px;
   background-color: #eeeeee;
-  margin-top: 10px;
+  margin-bottom: 10px;
 }
 
 .id {
@@ -184,10 +187,17 @@
   margin-bottom: 20px;
   border: solid 2px #ddd;
   border-radius: 5px;
+  padding: 10px;
 }
 
 .edit-form mat-form-field {
   // margin-bottom: -10px;
+}
+
+.characteristics-input-list {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
 }
 
 .title-input {

--- a/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.ts
+++ b/llm-recs/llm-recs-webclient/src/app/data-item/data-item.component.ts
@@ -10,8 +10,7 @@ import { Component, computed, EventEmitter, Input, OnInit, Output, Signal, signa
 import { DataItem, SavedDataService, dummyItem } from '../saved-data.service';
 import { FormControl } from '@angular/forms';
 import { LmApiService } from '../lm-api.service';
-import { isEmbedError } from 'src/lib/text-embeddings/embedder';
-
+import { ErrorResponse, isErrorResponse } from 'src/lib/simple-errors/simple-errors';
 
 // class SignalModel<T> {
 //   public signalValue: WritableSignal<T>;
@@ -120,7 +119,7 @@ export class DataItemComponent {
         newEmbeddings[key] = dataItem.embeddings[key];
       } else {
         const embedResponse = await this.lmApi.embedder.embed(key);
-        if (isEmbedError(embedResponse)) {
+        if (isErrorResponse(embedResponse)) {
           this.waiting = false;
           this.saveError = embedResponse.error;
           return;
@@ -141,7 +140,7 @@ export class DataItemComponent {
     delete this.saveError;
 
     const newItem = await this.dataService.createItem(this.dataItem().text);
-    if (isEmbedError(newItem)) {
+    if (isErrorResponse(newItem)) {
       this.waiting = false;
       this.saveError = newItem.error;
       return;

--- a/llm-recs/llm-recs-webclient/src/app/item-interpreter.service.ts
+++ b/llm-recs/llm-recs-webclient/src/app/item-interpreter.service.ts
@@ -8,8 +8,10 @@
 
 import { Injectable } from '@angular/core';
 import { LmApiService } from './lm-api.service';
-import { llmInput } from '../lib/recommender-prompts/item-interpreter';
+import { expInterpTempl, characteristicsTempl } from '../lib/recommender-prompts/item-interpreter';
 import { fillTemplate } from 'src/lib/text-templates/llm';
+import { matchFewShotTemplate } from 'src/lib/text-templates/fewshot_template';
+import { ErrorResponse, isErrorResponse } from 'src/lib/simple-errors/simple-errors';
 
 export interface InterpretedItem {
   entityTitle: string;
@@ -30,29 +32,34 @@ export class ItemInterpreterService {
     // public interpretationPrompt: Template<input, title, keys>
   ) { }
 
-  async interpretItemText(text: string): Promise<InterpretedItem> {
+  async interpretItemText(text: string): Promise<InterpretedItem | ErrorResponse> {
     const responses = await fillTemplate(
       this.lmApiService.llm,
-      llmInput.substs({experience: text}));
-    
+      expInterpTempl.substs({ experience: text }));
+
+    if (isErrorResponse(responses)) {
+      return responses;
+    }
+
     const badlyFormedResponsesCount = responses.filter(r => !r.substs).length;
     console.log(`badlyFormedResponses count: ${badlyFormedResponsesCount}`);
-    console.log(`responses: ${JSON.stringify(responses, null, 2)} `);    
+    console.log(`responses: ${JSON.stringify(responses, null, 2)} `);
 
-    if(responses.length === 0) {
+    if (responses.length === 0) {
       throw new Error('no responses');
     }
 
     const substs = responses[0].substs;
-    if(!substs) {
+    if (!substs) {
       throw new Error('no substs for initial response');
     }
     const title = substs.aboutEntity;
     const entityDetails = substs.aboutEntity;
     const sentiment = substs.likedOrDisliked;
-    const characteristicsListStr = `[ ${substs.characteristics} ]`;
-    console.log('characteristicsListStr:', characteristicsListStr);
-    const keys = JSON.parse(characteristicsListStr) as string[];
+
+    const charMatches = matchFewShotTemplate(
+      characteristicsTempl, substs.characteristics);
+    const keys = charMatches.map(c => c.substs.characteristic);
     return { entityTitle: title, text, entityDetails, sentiment, keys };
   }
 }

--- a/llm-recs/llm-recs-webclient/src/app/lm-api.service.ts
+++ b/llm-recs/llm-recs-webclient/src/app/lm-api.service.ts
@@ -24,6 +24,6 @@ export class LmApiService {
 
   constructor() {
     this.embedder = new SimpleEmbedder();
-    this.llm = new SimpleLlm();
+    this.llm = new SimpleLlm({ candidateCount: 1 });
   }
 }

--- a/llm-recs/llm-recs-webclient/src/app/rudders-home/rudders-home.component.html
+++ b/llm-recs/llm-recs-webclient/src/app/rudders-home/rudders-home.component.html
@@ -1,28 +1,35 @@
 <div class="main">
   <form>
-    <mat-form-field class="item-text-form">
-      <mat-label>Item Text</mat-label>
-      <textarea matInput [formControl]="itemTextControl"></textarea>
-      @if (waiting) {
-        <mat-progress-bar [mode]="'indeterminate'"></mat-progress-bar>
-      }
-      @if (errorMessage) {
-        <div class="error">
-          <div class="error-message">{{errorMessage}}</div>
-          <button mat-icon-button aria-label="dismiss error" (click)="dismissError()">
-            <mat-icon>close</mat-icon>
+    @if (itemToAdd !== null) {
+      <app-data-item [item]="itemToAdd" [editMode]="'edit'" (savedOrCancelled)="saveOrCancelAdd($event)"></app-data-item>
+    } @else {
+      <mat-form-field class="item-text-form">
+        <mat-label>Describe an Experience to add, search for, or recommend</mat-label>
+        <textarea matInput [formControl]="itemTextControl"></textarea>
+      </mat-form-field>
+
+      <div class="buttons-and-progress">
+        @if (waiting) {
+          <mat-progress-bar [mode]="'indeterminate'"></mat-progress-bar>
+        }
+        @if (errorMessage) {
+          <div class="error">
+            <div class="error-message">{{errorMessage}}</div>
+            <button mat-icon-button aria-label="dismiss error" (click)="dismissError()">
+              <mat-icon>close</mat-icon>
+            </button>
+          </div>
+        }
+        <div class="buttons">
+          <button mat-icon-button aria-label="add" (click)="add()">
+            <mat-icon>add</mat-icon>
+          </button>
+          <button [disabled]="hasNoInput()" mat-icon-button aria-label="search" (click)="search()">
+            <mat-icon>search</mat-icon>
           </button>
         </div>
-      }
-    </mat-form-field>
-    <div class="buttons">
-      <button [disabled]="hasNoInput()" mat-icon-button aria-label="add" (click)="add()">
-        <mat-icon>add</mat-icon>
-      </button>
-      <button [disabled]="hasNoInput()" mat-icon-button aria-label="search" (click)="search()">
-        <mat-icon>search</mat-icon>
-      </button>
-    </div>
+      </div>
+    }
   </form>
   <div class="search-response-sep"></div>
   <app-data-viewer [search]="searchSpec"></app-data-viewer>

--- a/llm-recs/llm-recs-webclient/src/app/rudders-home/rudders-home.component.scss
+++ b/llm-recs/llm-recs-webclient/src/app/rudders-home/rudders-home.component.scss
@@ -1,8 +1,11 @@
 .main {
 }
 
+.buttons-and-progress {
+  margin-top: -18px;
+}
+
 .buttons {
-  margin-top: -20px;
 }
 
 .error {

--- a/llm-recs/llm-recs-webclient/src/app/rudders-home/rudders-home.component.ts
+++ b/llm-recs/llm-recs-webclient/src/app/rudders-home/rudders-home.component.ts
@@ -10,9 +10,9 @@ import { Component, WritableSignal, signal } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { DataItem, ItemEmbeddings, SavedDataService, emptyItem } from '../saved-data.service';
 import { LmApiService } from '../lm-api.service';
-import { isEmbedError } from 'src/lib/text-embeddings/embedder';
 import { SearchSpec } from '../data-viewer/data-viewer.component';
 import { ItemInterpreterService } from '../item-interpreter.service';
+import { isErrorResponse } from 'src/lib/simple-errors/simple-errors';
 
 @Component({
   selector: 'app-rudders-home',
@@ -49,7 +49,7 @@ export class RuddersHomeComponent {
     const embedResult = await this.lmApiService.embedder.embed(
       this.itemTextControl.value!);
 
-    if (isEmbedError(embedResult)) {
+    if (isErrorResponse(embedResult)) {
       this.waiting = false;
       this.errorMessage = embedResult.error;
       return;
@@ -80,7 +80,7 @@ export class RuddersHomeComponent {
 
     this.waiting = true;
     const itemOrError = await this.dataService.createItem(text);
-    if (isEmbedError(itemOrError)) {
+    if (isErrorResponse(itemOrError)) {
       this.waiting = false;
       this.errorMessage = itemOrError.error;
       return;

--- a/llm-recs/llm-recs-webclient/src/lib/recommender-prompts/item-interpreter.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/recommender-prompts/item-interpreter.ts
@@ -24,8 +24,8 @@ interface ExperienceTemplEntry {
   characteristics: string;
 }
 
-const characteristicsTempl = new FewShotTemplate(template`"${nv('characteristic')}"`,
-  ',\n  ');
+const characteristicsTempl = new FewShotTemplate(template`<characteristic-phrase>${nv('characteristic')}</characteristic-phrase>`,
+  '\n  ');
 
 const criteriaPoints: Experience[] = [
   {
@@ -61,12 +61,13 @@ const experienceTemplEntries: ExperienceTemplEntry[] = criteriaPoints.map(
     };
   })
 
-const itemExperienceTempl = template`Short experience description: "${nv('experience')}"
-About-Entity: ${nv('aboutEntity')} (${nv('aboutDetails')})
-Liked-Or-Disliked: ${nv('likedOrDisliked')}
-Key-Characteristics: [
+const itemExperienceTempl = template`<short-experience-description>${nv('experience')}</short-experience-description>
+<entity-name>${nv('aboutEntity')}</entity-name>
+<entity-detail>${nv('aboutDetails')}</entity-detail>
+<liked-or-disliked>${nv('likedOrDisliked')}</liked-or-disliked>
+<characteristics>
   ${nv('characteristics')}
-]`;
+</characteristics>`
 
 const itemExperiencesTempl = new FewShotTemplate(itemExperienceTempl, '\n\n');
 

--- a/llm-recs/llm-recs-webclient/src/lib/recommender-prompts/item-interpreter.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/recommender-prompts/item-interpreter.ts
@@ -24,7 +24,7 @@ interface ExperienceTemplEntry {
   characteristics: string;
 }
 
-const characteristicsTempl = new FewShotTemplate(template`<characteristic-phrase>${nv('characteristic')}</characteristic-phrase>`,
+export const characteristicsTempl = new FewShotTemplate(template`<characteristic-phrase>${nv('characteristic')}</characteristic-phrase>`,
   '\n  ');
 
 const criteriaPoints: Experience[] = [
@@ -81,7 +81,7 @@ ${itemExperienceTempl}`;
 // Example usage.
 const pastFewShotItemExperiences = itemExperiencesTempl.apply(experienceTemplEntries);
 
-export const llmInput = itemInterpreterTempl.substs({
+export const expInterpTempl = itemInterpreterTempl.substs({
   pastExperiences: pastFewShotItemExperiences.escaped,
   // experience: 'The Garden of Forking Paths: like it'
 });

--- a/llm-recs/llm-recs-webclient/src/lib/simple-errors/simple-errors.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/simple-errors/simple-errors.ts
@@ -1,0 +1,25 @@
+
+export interface AbstractErrorResponse {
+  error: unknown;
+}
+
+export interface ErrorResponse {
+  error: string;
+}
+
+export function isErrorResponse<T, E extends AbstractErrorResponse>(
+  response: T | E
+): response is E {
+  if ((response as E).error) {
+    return true;
+  }
+  return false;
+}
+
+export function assertNoErrorResponse<T, E extends AbstractErrorResponse>(
+  response: T | E
+): asserts response is T {
+  if ((response as E).error) {
+    throw new Error('response was an error after all');
+  }
+}

--- a/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder.ts
@@ -1,3 +1,5 @@
+import { ErrorResponse } from "../simple-errors/simple-errors";
+
 export interface Embedding {
   embedding: number[];
 }
@@ -6,25 +8,8 @@ export interface EmbedError {
   error: string;
 }
 
-export type EmbedResponse = Embedding | EmbedError;
-
-
-export function isEmbedError<T>(response: T | EmbedError): response is EmbedError {
-  if ((response as EmbedError).error) {
-    return true;
-  }
-  return false;
-}
-
-export function isNotEmbedError<T>(response: T | EmbedError): response is Exclude<T, EmbedError> {
-  if ((response as EmbedError).error) {
-    return true;
-  }
-  return false;
-}
-
 export abstract class Embedder<Params extends {}> {
   public abstract name: string;
 
-  abstract embed(prompt: string, params?: Params): Promise<EmbedResponse>;
+  abstract embed(prompt: string, params?: Params): Promise<Embedding | ErrorResponse>;
 }

--- a/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder.ts
@@ -8,7 +8,15 @@ export interface EmbedError {
 
 export type EmbedResponse = Embedding | EmbedError;
 
+
 export function isEmbedError<T>(response: T | EmbedError): response is EmbedError {
+  if ((response as EmbedError).error) {
+    return true;
+  }
+  return false;
+}
+
+export function isNotEmbedError<T>(response: T | EmbedError): response is Exclude<T, EmbedError> {
   if ((response as EmbedError).error) {
     return true;
   }

--- a/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder_api.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder_api.ts
@@ -6,13 +6,13 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { Embedder, EmbedResponse as EmbedResponse } from "./embedder";
+import { Embedder, Embedding, EmbedError } from "./embedder";
 
 interface EmbedRequest {
   text: string
 }
 
-async function sendEmbedRequest(request: EmbedRequest): Promise<EmbedResponse> {
+async function sendEmbedRequest(request: EmbedRequest): Promise<Embedding | EmbedError> {
   // Default options are marked with *
   // try {
   const response = await fetch(`/api/embed`, {
@@ -33,7 +33,7 @@ async function sendEmbedRequest(request: EmbedRequest): Promise<EmbedResponse> {
     console.error(response.statusText);
     return { error: `fetch request failed (${response.status}): ${response.statusText}` };
   }
-  return (await response.json() as EmbedResponse);
+  return (await response.json() as Embedding | EmbedError);
   // } catch (e: unknown) {
   //   console.error(e);
   //   return { error: `fetch request failed: ${(e as Error).message}` };
@@ -47,7 +47,7 @@ export class SimpleEmbedder implements Embedder<{}> {
   }
   async embed(
     text: string, params?: {}
-  ): Promise<EmbedResponse> {
+  ): Promise<Embedding | EmbedError> {
     const apiResponse = await sendEmbedRequest({ text });
     return apiResponse
   }

--- a/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder_vertexapi.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-embeddings/embedder_vertexapi.ts
@@ -6,7 +6,8 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { Embedder, EmbedResponse as EmbedResponse } from "./embedder";
+import { ErrorResponse, isErrorResponse } from "../simple-errors/simple-errors";
+import { Embedder, Embedding } from "./embedder";
 
 /*
 Google Cloud Vertex Embedding API
@@ -44,15 +45,6 @@ export interface VertexEmbedError {
   }
 }
 
-export type VertexEmbedResponse = VertexEmbedding | VertexEmbedError;
-
-function isErrorResponse(response: VertexEmbedResponse): response is VertexEmbedError {
-  if ((response as VertexEmbedError).error) {
-    return true;
-  }
-  return false;
-}
-
 export function prepareEmbedRequest(text: string, options?: EmbedRequestParams): EmbedRequest {
   return {
     instances: [{ content: text }],
@@ -84,7 +76,7 @@ export async function sendEmbedRequest(
   req: EmbedRequest,
   modelId = 'textembedding-gecko', // e.g. textembedding-gecko embedding model
   apiEndpoint = 'us-central1-aiplatform.googleapis.com',
-): Promise<VertexEmbedResponse> {
+): Promise<VertexEmbedding | VertexEmbedError> {
   return postDataToLLM(
     // TODO: it may be that the url part 'us-central1' has to match
     // apiEndpoint.
@@ -115,7 +107,7 @@ export class VertexEmbedder implements Embedder<EmbedApiOptions> {
 
   async embed(
     query: string, params?: EmbedApiOptions
-  ): Promise<EmbedResponse> {
+  ): Promise<Embedding | ErrorResponse> {
 
     const apiRequest: EmbedRequest = {
       instances: [{ content: query }],

--- a/llm-recs/llm-recs-webclient/src/lib/text-templates/fewshot_template.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-templates/fewshot_template.ts
@@ -23,7 +23,7 @@ See the test file (.spec) for more detailed examples.
 */
 
 import { flatten } from 'underscore';
-import { Template, escapeStr, template, nv, unEscapeStr } from './template';
+import { Template, escapeStr, template, nv, unEscapeStr, matchTemplate, TemplateMatch, escapeStringInMatch } from './template';
 import { NamedVar } from './variable';
 
 // For each example substitution, substitute it into the template, and join it
@@ -57,4 +57,29 @@ export class FewShotTemplate<Ns extends string> {
     return fewShotSubst(
       this.template, examples, this.joinStr);
   }
+}
+
+export function matchFewShotTemplate<Ns extends string>(
+  fewShotTempl: FewShotTemplate<Ns>, str: string
+): TemplateMatch<Ns>[] {
+  const matches: TemplateMatch<Ns>[] = [];
+  const parts = fewShotTempl.template.parts();
+  let match = matchTemplate(parts, str);
+  matches.push(match);
+  while (
+    match.matchedPartsCount === match.parts.variables.length &&
+    match.finalStr !== ''
+  ) {
+    let nextStr = match.finalStr
+    const sepMatch = match.finalStr.match(
+      `^${escapeStringInMatch(fewShotTempl.joinStr)}`);
+    if (sepMatch) {
+      nextStr = match.finalStr.slice(sepMatch[0].length);
+    } else {
+      return matches;
+    }
+    match = matchTemplate(parts, nextStr);
+    matches.push(match);
+  }
+  return matches;
 }

--- a/llm-recs/llm-recs-webclient/src/lib/text-templates/llm.spec.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-templates/llm.spec.ts
@@ -115,7 +115,6 @@ summary: ['${nv('summary')}']`;
 
     const substsList = await fillTemplate(
       fakeLLM, promptTempl.substs({ movie: 'The Godfather' }));
-    console.log('substsList: ', substsList);
     expect(substsList.length).toEqual(4);
     expect(substsList[0].substs!.summary).toEqual(`an operatic tale of a powerful family`);
     expect(substsList[1].substs!.summary).toEqual(`an operatic tragedy about a powerful Italian American crime family', 'a sprawling epic of violence and betrayal`);

--- a/llm-recs/llm-recs-webclient/src/lib/text-templates/llm.spec.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-templates/llm.spec.ts
@@ -10,7 +10,7 @@
 Showing how the LLM class works...
 */
 
-import { LookupTableFakeLLM, PredictResponse, ScoreResponse, ScoredCompletion, fillTemplate } from "./llm";
+import { LookupTableFakeLLM, PredictResponse, ScoreResponse, ScoredCompletion, assertNoErrorResponse, fillTemplate, isErrorResponse } from "./llm";
 import { Palm2Response, preparePalm2Request } from "./llm_vertexapi_palm2";
 import { nv, template } from "./template";
 
@@ -115,6 +115,7 @@ summary: ['${nv('summary')}']`;
 
     const substsList = await fillTemplate(
       fakeLLM, promptTempl.substs({ movie: 'The Godfather' }));
+    assertNoErrorResponse(substsList);
     expect(substsList.length).toEqual(4);
     expect(substsList[0].substs!.summary).toEqual(`an operatic tale of a powerful family`);
     expect(substsList[1].substs!.summary).toEqual(`an operatic tragedy about a powerful Italian American crime family', 'a sprawling epic of violence and betrayal`);
@@ -145,6 +146,7 @@ rating (1 to 5 scale): ${nv('rating', { match: '[12345](\.\\d)?' })}
 synopsis: '${nv('synopsis')}'`;
 
     const responses = await fillTemplate(fakeLLM, t.substs({ movie }));
+    assertNoErrorResponse(responses);
     expect(responses[0].substs!.summaries).toEqual(` 80s cop drama with an amazing cast', 'stylish and suspenseful`);
     expect(responses[0].substs!.rating).toEqual(`4`);
     expect(responses[1].substs!.summaries).toEqual(` stylish and gritty gangster movie of the prohibition era', 'the classic good vs evil tale`);

--- a/llm-recs/llm-recs-webclient/src/lib/text-templates/llm.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-templates/llm.ts
@@ -10,12 +10,12 @@
 An class to wrap, and provide a common interface for LLM behaviour.
 */
 
+import { ErrorResponse, isErrorResponse } from "../simple-errors/simple-errors";
 import { Template, matchTemplate } from "./template";
 
 export interface PredictResponse {
   completions: string[];
 }
-
 
 export interface ScoreRequest {
   query: string;
@@ -30,11 +30,10 @@ export interface ScoreResponse {
   scoredCompletions: ScoredCompletion[];
 }
 
-
 export abstract class LLM<Params extends {}> {
   public abstract name: string;
 
-  abstract predict(prompt: string, params?: Params): Promise<PredictResponse>;
+  abstract predict(prompt: string, params?: Params): Promise<PredictResponse | ErrorResponse>;
   // abstract score(request: ScoreRequest): Promise<ScoreResponse>;
 }
 
@@ -74,11 +73,14 @@ export interface InterpretedResponse<Ns extends string> {
 
 export async function fillTemplate<Ns extends string>(
   llm: LLM<{}>, template: Template<Ns>
-): Promise<InterpretedResponse<Ns>[]> {
+): Promise<InterpretedResponse<Ns>[] | ErrorResponse> {
   const interpretedResponses = [] as InterpretedResponse<Ns>[];
   // const substsResponses: ({ [Key in Ns]: string } | null)[] = [];
   const parts = template.parts();
   const responses = await llm.predict(parts.prefix);
+  if (isErrorResponse(responses)) {
+    return responses;
+  }
   // console.log('parts.prefix: ', parts.prefix);
   for (const completion of responses.completions) {
     // console.log('parts', parts);

--- a/llm-recs/llm-recs-webclient/src/lib/text-templates/llm.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-templates/llm.ts
@@ -86,7 +86,7 @@ export async function fillTemplate<Ns extends string>(
     const match = matchTemplate(parts, completion, false);
     const interpretedResponse = { responseStr: completion } as InterpretedResponse<Ns>;
     if (match) {
-      interpretedResponse.substs = match;
+      interpretedResponse.substs = match.substs;
     }
     interpretedResponses.push(interpretedResponse)
   }

--- a/llm-recs/llm-recs-webclient/src/lib/text-templates/scripts/run_vertexapi_palm2_predict_rec_test.ts
+++ b/llm-recs/llm-recs-webclient/src/lib/text-templates/scripts/run_vertexapi_palm2_predict_rec_test.ts
@@ -23,7 +23,7 @@ Assumes that you have run:
 */
 import { VertexPalm2LLM } from '../llm_vertexapi_palm2';
 import { FewShotTemplate } from '../fewshot_template';
-import { llmInput } from '../../recommender-prompts/item-interpreter';
+import { expInterpTempl } from '../../recommender-prompts/item-interpreter';
 
 
 import * as yargs from 'yargs';
@@ -45,7 +45,7 @@ async function run(args: Params): Promise<void> {
     args.project,
     args.accessToken,
   );
-  const templateToFill = llmInput.substs({ experience: args.experience });
+  const templateToFill = expInterpTempl.substs({ experience: args.experience });
   console.log('template: \n\n', templateToFill.escaped);
   console.log('\n\n');
   const responses = await fillTemplate(llm, templateToFill);


### PR DESCRIPTION
- adds a stage of viewing by a user after text is interpretated to be a new dataItem, before it's saved; where user can edit it.
- Improved UI for data-view of data items & support for re-interpretation.
  - fixes issue: allow user to add more characteristics. 
- Added parsing for few-shot templates
- Improved parser code for templates (maybe good to have a class wrapper for the match object?)
- Introduced a simple common error handling lib, and used it for all client code and some backend code.
- SimpleLLM API cleanup and  support for overrides of arbitrary params.

Some things we should followup with soon: 

* Make a consolidated separate package/npm entry for the basic template and llm libraries, and for the simple errors; avoiding these libraries becoming inconsistent between server and client. (they already are somewhat, e.g. llm calling gaxios is ahead in server, and templates are ahead on client).
* Improvements to the template: we should have a few more examples, including some longer ones. (it doesn't work well right now w.r.t. picking the entity/title for long entries. 
* UI for the template to be edited in the UI, and saved, and in time use RAG entries. 
* Support making suggestion
* Support searching past ones better (use an LLM to help you interpret?) 
* use the cloud entity API to load up nice pictures and help people choose entities being discussed. 
* add saving/loading/sharing (via google drive), with a dirve URL param.