### PR TITLE
update data model for being user-specific + add basic survey component

### DIFF
--- a/llm-meditators/webapp/src/app/app-settings/app-settings.component.ts
+++ b/llm-meditators/webapp/src/app/app-settings/app-settings.component.ts
@@ -14,7 +14,7 @@ import { GoogleSheetsService, isSheetsError } from '../google-sheets.service';
 import { GoogleAuthService } from '../google-auth.service';
 import { GoogleDriveAppdataService } from '../google-drive-appdata.service';
 import { ItemInterpreterService } from '../item-interpreter.service';
-import { ErrorResponse, isErrorResponse } from 'src/lib/simple-errors/simple-errors';
+import { SimpleError, isErrorResponse } from 'src/lib/simple-errors/simple-errors';
 
 
 @Component({

--- a/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.html
+++ b/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.html
@@ -1,13 +1,17 @@
+@if (error() == null) {
 <div class="main">
-    <!-- Survey where users can select their prefered pronouns -->
-    <h2>Preferred Pronouns Survey</h2>
-    <p>
-        Please select your preferred pronouns. This will be used to refer to you in the app.
-    </p>
-
-    <mat-radio-group class="pronouns-radio-group" [value]="pronouns" (change)="setPronouns($event)">
-        <mat-radio-button class="pronouns-radio-button" [value]="PronounPair.SHE">{{ PronounPair.SHE }}</mat-radio-button>
-        <mat-radio-button class="pronouns-radio-button" [value]="PronounPair.THEY">{{ PronounPair.THEY }}</mat-radio-button>
-        <mat-radio-button class="pronouns-radio-button" [value]="PronounPair.HE">{{ PronounPair.HE }}</mat-radio-button>
-    </mat-radio-group>
+  <div>
+    Question: {{stageData().question}}
+  </div>
+  <form class="settings-form">
+    <mat-form-field class="full-width">
+      <mat-label>Answer</mat-label>
+      <input matInput placeholder="Write your response" [formControl]="responseControl">
+    </mat-form-field>
+  </form>
 </div>
+} @else {
+  <div class="error">
+    {{error()}}
+  </div>
+}

--- a/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.html
+++ b/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.html
@@ -1,1 +1,13 @@
-<p>exp-survey works!</p>
+<div class="main">
+    <!-- Survey where users can select their prefered pronouns -->
+    <h2>Preferred Pronouns Survey</h2>
+    <p>
+        Please select your preferred pronouns. This will be used to refer to you in the app.
+    </p>
+
+    <mat-radio-group class="pronouns-radio-group" [value]="pronouns" (change)="setPronouns($event)">
+        <mat-radio-button class="pronouns-radio-button" [value]="PronounPair.SHE">{{ PronounPair.SHE }}</mat-radio-button>
+        <mat-radio-button class="pronouns-radio-button" [value]="PronounPair.THEY">{{ PronounPair.THEY }}</mat-radio-button>
+        <mat-radio-button class="pronouns-radio-button" [value]="PronounPair.HE">{{ PronounPair.HE }}</mat-radio-button>
+    </mat-radio-group>
+</div>

--- a/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.scss
+++ b/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.scss
@@ -1,0 +1,20 @@
+.main {
+    padding: 2rem 1rem;
+  }
+  
+  label {
+    font-weight: bold;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  
+  .pronouns-radio-group {
+    display: flex;
+    align-items: center;
+  
+    .pronouns-radio-button {
+      margin: 5px;
+      -webkit-user-select: none;
+      user-select: none;
+    }
+  }

--- a/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.ts
+++ b/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.ts
@@ -1,19 +1,27 @@
 import { Component } from '@angular/core';
-import { SavedDataService } from '../saved-data.service';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatButtonModule } from '@angular/material/button';
+import { SavedDataService, PronounPair } from '../saved-data.service';
 
 @Component({
   selector: 'app-exp-survey',
   standalone: true,
-  imports: [],
+  imports: [MatRadioModule, MatButtonModule],
   templateUrl: './exp-survey.component.html',
   styleUrl: './exp-survey.component.scss'
 })
 export class ExpSurveyComponent {
-
+  readonly PronounPair = PronounPair;
+  pronouns = PronounPair.THEY;
   constructor(
     private dataService: SavedDataService,
   ) {
-    this.dataService.appName()
+    console.log(dataService);
+  }
+
+  setPronouns(event: any) {
+    this.pronouns = event.value;
+    console.log(this.pronouns);
   }
 
 }

--- a/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.ts
+++ b/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.ts
@@ -1,27 +1,78 @@
-import { Component } from '@angular/core';
-import { MatRadioModule } from '@angular/material/radio';
-import { MatButtonModule } from '@angular/material/button';
-import { SavedDataService, PronounPair } from '../saved-data.service';
+import { Component, Signal, WritableSignal, computed, signal } from '@angular/core';
+import { AppData, ExpStageSimpleSurvey, SavedDataService,  } from '../saved-data.service';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { SimpleError, isErrorResponse as isSimpleError } from 'src/lib/simple-errors/simple-errors';
 
+const dummySurveyData: ExpStageSimpleSurvey = {
+  kind: 'survey',
+  name: 'error name',
+  question: 'error: this should never happen',
+  response: {
+    // score: 
+    openFeedback: '',
+  },
+}
 @Component({
   selector: 'app-exp-survey',
   standalone: true,
-  imports: [MatRadioModule, MatButtonModule],
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
   templateUrl: './exp-survey.component.html',
   styleUrl: './exp-survey.component.scss'
 })
 export class ExpSurveyComponent {
-  readonly PronounPair = PronounPair;
-  pronouns = PronounPair.THEY;
+  public responseControl: FormControl<string | null>;
+  public stageData: Signal<ExpStageSimpleSurvey>;
+  public error: Signal<string | null>;
+
   constructor(
     private dataService: SavedDataService,
   ) {
-    console.log(dataService);
-  }
+    this.error = computed(() => {
+      if(!this.dataService.data().experiment.currentStage) {
+        return `currentStage is undefined`;
+      }
+      if(this.dataService.nameStageMap()[
+        this.dataService.data().experiment.currentStage]) {
+        return null;
+      }
+      return `this.dataService.data().experiment.currentStage is not in the map`;
+    });
 
-  setPronouns(event: any) {
-    this.pronouns = event.value;
-    console.log(this.pronouns);
-  }
+    // Assumption: this is only ever constructed when 
+    // `this.dataService.data().experiment.currentStage` references a 
+    // ExpStageSimpleSurvey.
+    this.stageData = computed(() => {
+      console.log(this.error())
+      console.log(this.dataService.nameStageMap())
+      console.log(this.dataService.data().experiment.currentStage);
 
+      const stageData = this.dataService.nameStageMap()[
+        this.dataService.data().experiment.currentStage]
+      if (!stageData) {
+        return dummySurveyData;
+      }
+      return stageData as ExpStageSimpleSurvey;
+    });
+
+    this.responseControl = new FormControl<string>('');
+    this.responseControl.valueChanges.forEach(n => {
+      if (n) {
+        const curStageData = this.stageData();
+        if(isSimpleError(curStageData)) {
+          return;
+        }
+        curStageData.response =  {
+          openFeedback: n
+        }
+        this.dataService.updateExpStage(curStageData); };
+        console.log(this.stageData());
+    });
+  }
 }

--- a/llm-meditators/webapp/src/app/item-interpreter.service.ts
+++ b/llm-meditators/webapp/src/app/item-interpreter.service.ts
@@ -11,7 +11,7 @@ import { LmApiService } from './lm-api.service';
 import { expInterpTempl, characteristicsTempl } from '../lib/recommender-prompts/item-interpreter';
 import { fillTemplate } from 'src/lib/text-templates/llm';
 import { matchFewShotTemplate } from 'src/lib/text-templates/fewshot_template';
-import { ErrorResponse, isErrorResponse } from 'src/lib/simple-errors/simple-errors';
+import { SimpleError, isErrorResponse } from 'src/lib/simple-errors/simple-errors';
 
 export interface InterpretedItem {
   entityTitle: string;
@@ -31,7 +31,7 @@ export class ItemInterpreterService {
     // public interpretationPrompt: Template<input, title, keys>
   ) {}
 
-  async interpretItemText(text: string): Promise<InterpretedItem | ErrorResponse> {
+  async interpretItemText(text: string): Promise<InterpretedItem | SimpleError> {
     const responses = await fillTemplate(this.lmApiService.llm, expInterpTempl.substs({ experience: text }));
 
     if (isErrorResponse(responses)) {

--- a/llm-meditators/webapp/src/app/saved-data.service.ts
+++ b/llm-meditators/webapp/src/app/saved-data.service.ts
@@ -48,6 +48,12 @@ export enum LeaderVote {
   NEGATIVE = 'negative',
   NOT_RATED = 'not-rated',
 }
+
+export enum PronounPair {
+  SHE = 'She/Her',
+  THEY = 'They/Them',
+  HE = 'He/Him',
+}
 interface ExpStageLeaderVote extends BasicExpStage {
   kind: 'leader-vote';
   // Map from a user to their votes on other users.

--- a/llm-meditators/webapp/src/lib/simple-errors/simple-errors.ts
+++ b/llm-meditators/webapp/src/lib/simple-errors/simple-errors.ts
@@ -1,13 +1,20 @@
+/*==============================================================================
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an Apache2 license that can be
+ * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
+==============================================================================*/
 
-export interface AbstractErrorResponse {
+export interface AbstractSimpleResponse {
   error: unknown;
 }
 
-export interface ErrorResponse {
+export interface SimpleError {
   error: string;
 }
 
-export function isErrorResponse<T, E extends AbstractErrorResponse>(
+export function isErrorResponse<T, E extends AbstractSimpleResponse>(
   response: T | E
 ): response is E {
   if ((response as E).error) {
@@ -16,7 +23,7 @@ export function isErrorResponse<T, E extends AbstractErrorResponse>(
   return false;
 }
 
-export function assertNoErrorResponse<T, E extends AbstractErrorResponse>(
+export function assertNoErrorResponse<T, E extends AbstractSimpleResponse>(
   response: T | E
 ): asserts response is T {
   if ((response as E).error) {

--- a/llm-meditators/webapp/src/lib/text-embeddings/embedder.ts
+++ b/llm-meditators/webapp/src/lib/text-embeddings/embedder.ts
@@ -1,4 +1,4 @@
-import { ErrorResponse } from "../simple-errors/simple-errors";
+import { SimpleError } from "../simple-errors/simple-errors";
 
 export interface Embedding {
   embedding: number[];
@@ -11,5 +11,5 @@ export interface EmbedError {
 export abstract class Embedder<Params extends {}> {
   public abstract name: string;
 
-  abstract embed(prompt: string, params?: Params): Promise<Embedding | ErrorResponse>;
+  abstract embed(prompt: string, params?: Params): Promise<Embedding | SimpleError>;
 }

--- a/llm-meditators/webapp/src/lib/text-embeddings/embedder_vertexapi.ts
+++ b/llm-meditators/webapp/src/lib/text-embeddings/embedder_vertexapi.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { ErrorResponse, isErrorResponse } from "../simple-errors/simple-errors";
+import { SimpleError, isErrorResponse } from "../simple-errors/simple-errors";
 import { Embedder, Embedding } from "./embedder";
 
 /*
@@ -107,7 +107,7 @@ export class VertexEmbedder implements Embedder<EmbedApiOptions> {
 
   async embed(
     query: string, params?: EmbedApiOptions
-  ): Promise<Embedding | ErrorResponse> {
+  ): Promise<Embedding | SimpleError> {
 
     const apiRequest: EmbedRequest = {
       instances: [{ content: query }],

--- a/llm-meditators/webapp/src/lib/text-templates/llm.ts
+++ b/llm-meditators/webapp/src/lib/text-templates/llm.ts
@@ -10,7 +10,7 @@
 An class to wrap, and provide a common interface for LLM behaviour.
 */
 
-import { ErrorResponse, isErrorResponse } from "../simple-errors/simple-errors";
+import { SimpleError, isErrorResponse } from "../simple-errors/simple-errors";
 import { Template, matchTemplate } from "./template";
 
 export interface PredictResponse {
@@ -33,7 +33,7 @@ export interface ScoreResponse {
 export abstract class LLM<Params extends {}> {
   public abstract name: string;
 
-  abstract predict(prompt: string, params?: Params): Promise<PredictResponse | ErrorResponse>;
+  abstract predict(prompt: string, params?: Params): Promise<PredictResponse | SimpleError>;
   // abstract score(request: ScoreRequest): Promise<ScoreResponse>;
 }
 
@@ -73,7 +73,7 @@ export interface InterpretedResponse<Ns extends string> {
 
 export async function fillTemplate<Ns extends string>(
   llm: LLM<{}>, template: Template<Ns>
-): Promise<InterpretedResponse<Ns>[] | ErrorResponse> {
+): Promise<InterpretedResponse<Ns>[] | SimpleError> {
   const interpretedResponses = [] as InterpretedResponse<Ns>[];
   // const substsResponses: ({ [Key in Ns]: string } | null)[] = [];
   const parts = template.parts();


### PR DESCRIPTION
specific user input rather whole experiement. user inside client should only see their personal 

In this PR: 

- changed the data model to remove backend and only focus on specific user's data (rather the whole experiment) since user should only see their own data.
- added a basic survey component with a free form that directly updates the data from an Experiment's Stage (`stageData`). "currentStage" indicates the current stage name. `nameStageMap` useful to get the stageData from the `currentStage` name

<img width="426" alt="Screenshot 2024-01-18 at 13 24 20" src="https://github.com/PAIR-code/recommendation-rudders/assets/25940954/ca5e9fa8-c385-4025-a9e6-8eef896f2071">


- Some error management

TODO: 
- Add slider to survey, create the other survey (there are 2 surveys , one before and one after the discussion)