### PR TITLE
support for navigating back to past stages

### DIFF
--- a/llm-meditators/webapp/src/app/app-home/app-home.component.html
+++ b/llm-meditators/webapp/src/app/app-home/app-home.component.html
@@ -6,7 +6,7 @@
       <app-exp-profile></app-exp-profile>
     } @else if (this.dataService.currentStage().kind === stageKinds.STAGE_KIND_CHAT) {
       <app-exp-chat></app-exp-chat>
-    <!-- } @else if (this.dataService.currentStage().kind === stageKinds.STAGE_KIND_RANKED_ITEMS) {
+      <!-- } @else if (this.dataService.currentStage().kind === stageKinds.STAGE_KIND_RANKED_ITEMS) {
       <app-exp-rating></app-exp-rating> -->
     } @else if (this.dataService.currentStage().kind === stageKinds.STAGE_KIND_TOS_AND_PROFILE) {
       <app-exp-tos-and-profile></app-exp-tos-and-profile>

--- a/llm-meditators/webapp/src/app/app-home/app-home.component.html
+++ b/llm-meditators/webapp/src/app/app-home/app-home.component.html
@@ -1,5 +1,5 @@
 <div class="main">
-  <div>
+  <div class="exp-stage-content">
     @if (this.dataService.currentStage().kind === stageKinds.STAGE_KIND_ACCEPT_TOS) {
       <app-exp-tos></app-exp-tos>
     } @else if (this.dataService.currentStage().kind === stageKinds.STAGE_KIND_PROFILE) {
@@ -22,7 +22,13 @@
         <span>{{ this.dataService.currentStage().kind }}</span>
       </div>
     }
+    @if (currentStageName() !== workingOnStageName()) {
+      <div class="mask">
+        <!-- TODO: should probably disable editing in individual stage components as well -->
+      </div>
+    }
   </div>
+
   @if (this.dataService.user().futureStageNames.length !== 0) {
     <button color="primary" mat-button (click)="nextStep()" [disabled]="holdingForLeaderReveal">
       <!-- [disabled]="!this.dataService.stageComplete()"  -->

--- a/llm-meditators/webapp/src/app/app-home/app-home.component.scss
+++ b/llm-meditators/webapp/src/app/app-home/app-home.component.scss
@@ -1,18 +1,36 @@
 .main {
   padding: 20px;
+
+  .exp-stage-content {
+    position: relative;
+    width: 100%;
+
+    .mask {
+      background-color: white;
+      opacity: 0.2;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      z-index: 9999999999;
+      cursor: not-allowed;
+    }
+  }
 }
 
 .buttons-and-progress {
   margin-top: -18px;
 }
 
-.buttons {}
+.buttons {
+}
 
 .error {
   padding: 5px;
   border-radius: 5px;
-  background-color: #FAA;
-  border: solid 1px #A00;
+  background-color: #faa;
+  border: solid 1px #a00;
   // color: #FF0000;
   display: flex;
 }

--- a/llm-meditators/webapp/src/app/app-home/app-home.component.ts
+++ b/llm-meditators/webapp/src/app/app-home/app-home.component.ts
@@ -6,19 +6,20 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { Component, Signal, computed } from '@angular/core';
-import { SavedDataService } from '../services/saved-data.service';
-import { LmApiService } from '../services/lm-api.service';
-import { ExpStage, ExpStageNames, stageKinds } from 'src/lib/staged-exp/data-model';
+import { ExpStageNames, stageKinds } from 'src/lib/staged-exp/data-model';
+
+import { Component, computed, Signal } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+
 import { ExpChatComponent } from '../exp-chat/exp-chat.component';
+import { ExpLeaderRevealComponent } from '../exp-leader-reveal/exp-leader-reveal.component';
 import { ExpLeaderVoteComponent } from '../exp-leader-vote/exp-leader-vote.component';
 import { ExpProfileComponent } from '../exp-profile/exp-profile.component';
 //import { ExpRatingComponent } from '../exp-rating/exp-rating.component';
 import { ExpSurveyComponent } from '../exp-survey/exp-survey.component';
 import { ExpTosAndProfileComponent } from '../exp-tos-and-profile/exp-tos-and-profile.component';
-import { ExpLeaderRevealComponent } from '../exp-leader-reveal/exp-leader-reveal.component';
 import { ExpTosComponent } from '../exp-tos/exp-tos.component';
-import { MatButtonModule } from '@angular/material/button';
+import { SavedDataService } from '../services/saved-data.service';
 
 @Component({
   selector: 'app-home',
@@ -40,22 +41,21 @@ import { MatButtonModule } from '@angular/material/button';
 export class AppHomeComponent {
   public everyoneReachedTheEnd: Signal<boolean>;
   public currentStageName: Signal<string>;
+  public workingOnStageName: Signal<string>;
   public holdingForLeaderReveal: boolean = false;
 
   public waiting: boolean = false;
   public errorMessage?: string;
   readonly stageKinds = stageKinds;
 
-  constructor(
-    private lmApiService: LmApiService,
-    public dataService: SavedDataService,
-  ) {
+  constructor(public dataService: SavedDataService) {
     this.everyoneReachedTheEnd = computed(() => {
       const users = Object.values(this.dataService.data().experiment.participants);
       return users.map((userData) => userData.futureStageNames.length).every((n) => n === 1);
     });
 
     this.currentStageName = computed(() => this.dataService.currentStage().name);
+    this.workingOnStageName = computed(() => this.dataService.user().workingOnStageName);
 
     this.holdingForLeaderReveal =
       this.currentStageName() === ExpStageNames['8. Leader reveal'] && !this.everyoneReachedTheEnd();

--- a/llm-meditators/webapp/src/app/app-home/app-home.component.ts
+++ b/llm-meditators/webapp/src/app/app-home/app-home.component.ts
@@ -9,7 +9,7 @@
 import { Component, Signal, computed } from '@angular/core';
 import { SavedDataService } from '../services/saved-data.service';
 import { LmApiService } from '../services/lm-api.service';
-import { ExpStageNames, stageKinds } from 'src/lib/staged-exp/data-model';
+import { ExpStage, ExpStageNames, stageKinds } from 'src/lib/staged-exp/data-model';
 import { ExpChatComponent } from '../exp-chat/exp-chat.component';
 import { ExpLeaderVoteComponent } from '../exp-leader-vote/exp-leader-vote.component';
 import { ExpProfileComponent } from '../exp-profile/exp-profile.component';

--- a/llm-meditators/webapp/src/app/app-settings/app-settings.component.ts
+++ b/llm-meditators/webapp/src/app/app-settings/app-settings.component.ts
@@ -6,14 +6,15 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { Component, ElementRef, OnInit, ViewChild, effect } from '@angular/core';
-import { AppData, SavedDataService, initialAppData } from '../services/saved-data.service';
+import { Component, effect, ElementRef, OnInit, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { LmApiService } from '../services/lm-api.service';
-import { GoogleSheetsService } from '../services/google-sheets.service';
+
+import { ConfigUpdate } from '../codemirror-config-editor/codemirror-config-editor.component';
 import { GoogleAuthService } from '../services/google-auth.service';
 import { GoogleDriveAppdataService } from '../services/google-drive-appdata.service';
-import { ConfigUpdate } from '../codemirror-config-editor/codemirror-config-editor.component';
+import { GoogleSheetsService } from '../services/google-sheets.service';
+import { LmApiService } from '../services/lm-api.service';
+import { AppData, initialAppData, SavedDataService } from '../services/saved-data.service';
 
 @Component({
   selector: 'app-app-settings',

--- a/llm-meditators/webapp/src/app/app.component.html
+++ b/llm-meditators/webapp/src/app/app.component.html
@@ -23,8 +23,13 @@
             routerLink="/"
             routerLinkActive="active"
             ariaCurrentWhenActive="page"
+            (click)="updateCurrentStageName(stageName)"
+            class="menu-item {{ stageName === dataService.user().currentStageName ? 'current-stage' : '' }}"
           >
-            {{ stageName }}
+            <div class="menu-item-inner">
+              {{ stageName }}
+              <mat-icon class="icon completed" fontIcon="check"></mat-icon>
+            </div>
           </mat-list-item>
         }
         <mat-list-item
@@ -33,8 +38,13 @@
           routerLink="/"
           routerLinkActive="active"
           ariaCurrentWhenActive="page"
+          class="menu-item working-on-stage"
+          (click)="updateCurrentStageName(workingOnStageName())"
         >
-          {{ currentStageName() }}
+          <div class="menu-item-inner">
+            {{ workingOnStageName() }}
+            <div class="ongoing-badge">ongoing</div>
+          </div>
         </mat-list-item>
         @for (stageName of dataService.user().futureStageNames; track stageName) {
           <mat-list-item
@@ -44,6 +54,7 @@
             routerLink="/"
             routerLinkActive="active"
             ariaCurrentWhenActive="page"
+            class="menu-item future-stage"
           >
             {{ stageName }}
           </mat-list-item>

--- a/llm-meditators/webapp/src/app/app.component.scss
+++ b/llm-meditators/webapp/src/app/app.component.scss
@@ -53,6 +53,41 @@ $toolbar-height: 60px;
   align-items: flex-start;
   flex: 1 1 auto;
   overflow: auto;
+
+  .current-stage {
+    background-color: #3f51b555;
+  }
+
+  .working-on-stage {
+    background-color: #ddd;
+  }
+
+  .menu-item-inner {
+    display: flex;
+    align-items: center;
+
+    .ongoing-badge {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 8px;
+      border-radius: 5px;
+      background-color: orange;
+      padding: 1px 4px;
+      line-height: 1.1rem;
+      color: #fff;
+      font-size: 12px;
+      opacity: 1;
+    }
+
+    .icon {
+      margin-left: 6px;
+
+      &.completed {
+        color: rgb(1, 133, 1);
+      }
+    }
+  }
 }
 
 .content .mat-drawer-container {

--- a/llm-meditators/webapp/src/app/app.component.ts
+++ b/llm-meditators/webapp/src/app/app.component.ts
@@ -22,6 +22,7 @@ export class AppComponent implements AfterViewInit {
 
   public currentStageKind: Signal<ExpStageKind>;
   public currentStageName: Signal<string>;
+  public workingOnStageName: Signal<string>;
 
   constructor(
     private route: ActivatedRoute,
@@ -31,6 +32,7 @@ export class AppComponent implements AfterViewInit {
   ) {
     this.currentStageKind = computed(() => this.dataService.currentStage().kind);
     this.currentStageName = computed(() => this.dataService.currentStage().name);
+    this.workingOnStageName = computed(() => this.dataService.user().workingOnStageName);
 
     effect(() => {
       // document.querySelector('title')!.textContent =
@@ -44,5 +46,10 @@ export class AppComponent implements AfterViewInit {
     // also uncomment stuff in html.
     this.authService.prompt();
     this.authService.renderLoginButton(this.googleButton.nativeElement);
+  }
+
+  updateCurrentStageName(stageName: string) {
+    console.log('updateViewingStageName', stageName);
+    this.dataService.setCurrentExpStageName(stageName);
   }
 }

--- a/llm-meditators/webapp/src/app/app.module.ts
+++ b/llm-meditators/webapp/src/app/app.module.ts
@@ -6,43 +6,42 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { NgModule } from '@angular/core';
-import { BrowserModule } from '@angular/platform-browser';
-
-import { AppRoutingModule } from './app-routing.module';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { AppComponent } from './app.component';
 import { AppHomeComponent } from './app-home/app-home.component';
+import { AppRoutingModule } from './app-routing.module';
 import { AppSettingsComponent } from './app-settings/app-settings.component';
-import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
-
-import { MatButtonModule } from '@angular/material/button';
-import { MatSelectModule } from '@angular/material/select';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatButtonToggleModule } from '@angular/material/button-toggle';
-import { MatIconModule } from '@angular/material/icon';
-import { MatListModule } from '@angular/material/list';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { MatInputModule } from '@angular/material/input';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatProgressBarModule } from '@angular/material/progress-bar';
-
-import { VertexApiService } from './services/vertex-api.service';
-import { SavedDataService } from './services/saved-data.service';
-import { LmApiService } from './services/lm-api.service';
-import { GoogleAuthService } from './services/google-auth.service';
-import { GoogleSheetsService } from './services/google-sheets.service';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { BrowserModule } from '@angular/platform-browser';
 import { CodemirrorConfigEditorModule } from './codemirror-config-editor/codemirror-config-editor.module';
-import { ExpLeaderVoteComponent } from './exp-leader-vote/exp-leader-vote.component';
-import { ExpProfileComponent } from './exp-profile/exp-profile.component';
 //import { ExpRatingComponent } from './exp-rating/exp-rating.component';
 import { ExpChatComponent } from './exp-chat/exp-chat.component';
-import { ExpTosComponent } from './exp-tos/exp-tos.component';
-import { ExpTosAndProfileComponent } from './exp-tos-and-profile/exp-tos-and-profile.component';
-import { ExpSurveyComponent } from './exp-survey/exp-survey.component';
 import { ExpLeaderRevealComponent } from './exp-leader-reveal/exp-leader-reveal.component';
+import { ExpLeaderVoteComponent } from './exp-leader-vote/exp-leader-vote.component';
+import { ExpProfileComponent } from './exp-profile/exp-profile.component';
+import { ExpSurveyComponent } from './exp-survey/exp-survey.component';
+import { ExpTosAndProfileComponent } from './exp-tos-and-profile/exp-tos-and-profile.component';
+import { ExpTosComponent } from './exp-tos/exp-tos.component';
+import { GoogleAuthService } from './services/google-auth.service';
+import { GoogleSheetsService } from './services/google-sheets.service';
+import { LmApiService } from './services/lm-api.service';
+import { MatBadgeModule } from '@angular/material/badge';
+import { MatButtonModule } from '@angular/material/button';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { NgModule } from '@angular/core';
+import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
+import { SavedDataService } from './services/saved-data.service';
+import { VertexApiService } from './services/vertex-api.service';
 
 @NgModule({
   declarations: [AppComponent, AppSettingsComponent, PageNotFoundComponent],
@@ -58,10 +57,12 @@ import { ExpLeaderRevealComponent } from './exp-leader-reveal/exp-leader-reveal.
     MatButtonToggleModule,
     MatIconModule,
     MatListModule,
+    MatBadgeModule,
     FormsModule,
     ReactiveFormsModule,
     MatFormFieldModule,
     MatInputModule,
+    MatChipsModule,
     MatMenuModule,
     MatProgressBarModule,
     CodemirrorConfigEditorModule,

--- a/llm-meditators/webapp/src/app/exp-leader-reveal/exp-leader-reveal.component.ts
+++ b/llm-meditators/webapp/src/app/exp-leader-reveal/exp-leader-reveal.component.ts
@@ -1,7 +1,9 @@
-import { Component, Signal, computed } from '@angular/core';
+import { reverse, sortBy } from 'lodash';
+import { ExpStageNames, Votes } from 'src/lib/staged-exp/data-model';
+
+import { Component, computed, Signal } from '@angular/core';
+
 import { SavedDataService } from '../services/saved-data.service';
-import { Votes, ExpStageNames } from 'src/lib/staged-exp/data-model';
-import { sortBy, reverse } from 'lodash';
 
 @Component({
   selector: 'app-exp-leader-reveal',

--- a/llm-meditators/webapp/src/app/exp-leader-vote/exp-leader-vote.component.ts
+++ b/llm-meditators/webapp/src/app/exp-leader-vote/exp-leader-vote.component.ts
@@ -6,11 +6,12 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { Component, Signal, computed } from '@angular/core';
-import { MatRadioModule } from '@angular/material/radio';
+import { Component, computed, Signal } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
-import { SavedDataService } from '../services/saved-data.service';
+import { MatRadioModule } from '@angular/material/radio';
+
 import { ExpStageVotes, LeaderVote, UserData, Votes } from '../../lib/staged-exp/data-model';
+import { SavedDataService } from '../services/saved-data.service';
 
 @Component({
   selector: 'app-exp-leader-vote',

--- a/llm-meditators/webapp/src/app/exp-profile/exp-profile.component.ts
+++ b/llm-meditators/webapp/src/app/exp-profile/exp-profile.component.ts
@@ -7,13 +7,14 @@
 ==============================================================================*/
 
 import { Component } from '@angular/core';
-import { MatRadioChange, MatRadioModule } from '@angular/material/radio';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { SavedDataService } from '../services/saved-data.service';
+import { MatRadioChange, MatRadioModule } from '@angular/material/radio';
+
 import { UserProfile } from '../../lib/staged-exp/data-model';
-import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SavedDataService } from '../services/saved-data.service';
 
 @Component({
   selector: 'app-exp-profile',

--- a/llm-meditators/webapp/src/app/exp-rating/exp-rating.component.ts
+++ b/llm-meditators/webapp/src/app/exp-rating/exp-rating.component.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { Component, Signal, computed } from '@angular/core';
+import { Component, computed, Signal } from '@angular/core';
 import { MatSliderModule } from '@angular/material/slider';
-import { SavedDataService } from '../services/saved-data.service';
+
 import { ExpStageItemRatings, ItemRatings, STAGE_KIND_RANKED_ITEMS } from '../../lib/staged-exp/data-model';
+import { SavedDataService } from '../services/saved-data.service';
 
 @Component({
   selector: 'app-exp-rating',

--- a/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.ts
+++ b/llm-meditators/webapp/src/app/exp-survey/exp-survey.component.ts
@@ -6,25 +6,14 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { Component, Signal, computed } from '@angular/core';
-import { SavedDataService } from '../services/saved-data.service';
+import { Component, computed, Signal } from '@angular/core';
 import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSliderModule } from '@angular/material/slider';
-import { Question, Survey, ItemRatings, ExpStageSurvey, STAGE_KIND_SURVEY } from '../../lib/staged-exp/data-model';
 
-const dummyQuestion: Question = {
-  questionText: 'error: this should never happen',
-  answerText: '',
-  lowerBound: "Lower Bound",
-  upperBound: "Upper Bound",
-  openFeedback: false,
-  score: null
-};
-const dummySurveyData: Survey = {
-  questions: [dummyQuestion],
-};
+import { ItemRatings, Question, STAGE_KIND_SURVEY, Survey } from '../../lib/staged-exp/data-model';
+import { SavedDataService } from '../services/saved-data.service';
 
 @Component({
   selector: 'app-exp-survey',
@@ -52,7 +41,7 @@ export class ExpSurveyComponent {
     });
 
     // if one of the this.currentStage().question
-    // has an itemRatings, then we use that one. Assumes max 
+    // has an itemRatings, then we use that one. Assumes max
     // one itemRatings question per stage.
     for (let i = 0; i < this.stageData().questions.length; i++) {
       if (this.stageData().questions[i].itemRatings) {
@@ -62,7 +51,7 @@ export class ExpSurveyComponent {
 
     this.responseControl = new Array(this.stageData().questions.length);
     for (let i = 0; i < this.stageData().questions.length; i++) {
-      this.responseControl[i] = new FormControl<string>("");
+      this.responseControl[i] = new FormControl<string>('');
     }
     for (let i = 0; i < this.stageData().questions.length; i++) {
       this.responseControl[i].valueChanges.forEach((n) => {
@@ -82,7 +71,6 @@ export class ExpSurveyComponent {
     this.dataService.editCurrentExpStageData(() => curStageData);
     console.log(this.stageData());
   }
-
 
   setChoice(questionIdx: number, pairIdx: number, choice: 'item1' | 'item2') {
     if (this.itemRatings) {

--- a/llm-meditators/webapp/src/app/exp-tos-and-profile/exp-tos-and-profile.component.ts
+++ b/llm-meditators/webapp/src/app/exp-tos-and-profile/exp-tos-and-profile.component.ts
@@ -7,14 +7,15 @@
 ==============================================================================*/
 
 import { Component } from '@angular/core';
-import { SavedDataService } from '../services/saved-data.service';
-import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
-import { MatRadioChange, MatRadioModule } from '@angular/material/radio';
+import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatRadioChange, MatRadioModule } from '@angular/material/radio';
+
 import { STAGE_KIND_TOS_AND_PROFILE, TosAndUserProfile } from '../../lib/staged-exp/data-model';
-import { FormControl, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { SavedDataService } from '../services/saved-data.service';
 
 @Component({
   selector: 'app-exp-tos-and-profile',

--- a/llm-meditators/webapp/src/app/exp-tos/exp-tos.component.ts
+++ b/llm-meditators/webapp/src/app/exp-tos/exp-tos.component.ts
@@ -6,10 +6,11 @@
  * found in the LICENSE file and http://www.apache.org/licenses/LICENSE-2.0
 ==============================================================================*/
 
-import { Component, Signal, computed } from '@angular/core';
-import { SavedDataService } from '../services/saved-data.service';
-import { TosAcceptance } from '../../lib/staged-exp/data-model';
+import { Component, computed, Signal } from '@angular/core';
 import { MatCheckboxChange, MatCheckboxModule } from '@angular/material/checkbox';
+
+import { TosAcceptance } from '../../lib/staged-exp/data-model';
+import { SavedDataService } from '../services/saved-data.service';
 
 @Component({
   selector: 'app-exp-tos',

--- a/llm-meditators/webapp/src/lib/staged-exp/data-model.ts
+++ b/llm-meditators/webapp/src/lib/staged-exp/data-model.ts
@@ -241,6 +241,7 @@ export interface UserData {
   stageMap: { [stageName: string]: ExpStage };
   completedStageNames: string[]; // current stage is the very last one.
   currentStageName: string;
+  workingOnStageName: string;
   futureStageNames: string[];
 }
 

--- a/llm-meditators/webapp/src/lib/staged-exp/example-experiment.ts
+++ b/llm-meditators/webapp/src/lib/staged-exp/example-experiment.ts
@@ -61,22 +61,22 @@ function acceptTosAndSetProfile(): ExpStageTosAndUserProfile {
 //   };
 // }
 const initialItemRatingsQuestion: Question = {
-  questionText: "",
-  itemRatings: { 
+  questionText: '',
+  itemRatings: {
     ratings: [
       { item1: items.compas, item2: items.blanket, choice: null, confidence: null },
       { item1: items.compas, item2: items.lighter, choice: null, confidence: null },
-    ]
-  }
-}
+    ],
+  },
+};
 
 const initialWantToLeadQuestion: Question = {
   questionText: `Rate the how much you would like to be the group leader.`,
-  lowerBound: "I would most definitely not like to be the leader (0/10)",
-  upperBound: "I will fight to be the leader (10/10)",
+  lowerBound: 'I would most definitely not like to be the leader (0/10)',
+  upperBound: 'I will fight to be the leader (10/10)',
   openFeedback: false,
   score: null,
-}
+};
 function initialWantToLeadSurvey(): ExpStageSurvey {
   return {
     kind: stageKinds.STAGE_KIND_SURVEY,
@@ -104,11 +104,11 @@ const chatDiscussionQuestion: Question = {
   questionText: `Rate the chat dicussion on a 1-10 scale.
 Also indicate your overall feeling about the chat.`,
   answerText: '',
-  lowerBound: "I did not enjoy the discussion at all (0/10)",
-  upperBound: "The dicussion was a perfect experience to me (10/10)",
+  lowerBound: 'I did not enjoy the discussion at all (0/10)',
+  upperBound: 'The dicussion was a perfect experience to me (10/10)',
   openFeedback: true,
   score: null,
-}
+};
 
 function chatDiscussionSurvey(): ExpStageSurvey {
   return {
@@ -124,11 +124,11 @@ function chatDiscussionSurvey(): ExpStageSurvey {
 const postChatWantToLeadQuestion: Question = {
   questionText: `Rate the how much you would like to be the group leader.`,
   answerText: '',
-  lowerBound: "I would most definitely not like to be the leader (0/10)",
-  upperBound: "I will fight to be the leader (10/10)",
+  lowerBound: 'I would most definitely not like to be the leader (0/10)',
+  upperBound: 'I will fight to be the leader (10/10)',
   openFeedback: false,
   score: null,
-}
+};
 
 function postChatWantToLeadSurvey(): ExpStageSurvey {
   return {
@@ -152,15 +152,14 @@ function leaderVoting(): ExpStageVotes {
 }
 
 const finalItemRatingsQuestion: Question = {
-  questionText: "",
-  itemRatings: { 
+  questionText: '',
+  itemRatings: {
     ratings: [
       { item1: items.compas, item2: items.blanket, choice: null, confidence: null },
       { item1: items.compas, item2: items.lighter, choice: null, confidence: null },
-    ]
-  }
-}
-
+    ],
+  },
+};
 
 function postChatWork(): ExpStageSurvey {
   return {
@@ -185,16 +184,15 @@ function leaderReveal(): ExpStageLeaderReveal {
   };
 }
 
-
 const finalSatisfactionQuestion: Question = {
   questionText: `Rate how happy you were with the final outcome.
 Also indicate your overall feeling about the experience.`,
   answerText: '',
-  lowerBound: "I was most definitely disappointed (0/10)",
-  upperBound: "I was very happy (10/10)",
+  lowerBound: 'I was most definitely disappointed (0/10)',
+  upperBound: 'I was very happy (10/10)',
   openFeedback: true,
   score: null,
-}
+};
 
 function finalSatisfactionSurvey(): ExpStageSurvey {
   return {
@@ -218,6 +216,7 @@ export function initUserData(stages: ExpStage[]): UserData {
   if (!currentStageName) {
     throw new Error('Cannot create a user with no experimental stages to do');
   }
+  const workingOnStageName = currentStageName;
 
   const userId = `uid:${uuidv4()}`;
 
@@ -231,6 +230,7 @@ export function initUserData(stages: ExpStage[]): UserData {
     },
     stageMap,
     currentStageName,
+    workingOnStageName,
     completedStageNames: [] as string[],
     futureStageNames,
   };


### PR DESCRIPTION
<img width="500" alt="Screenshot 2024-01-24 at 3 21 13 PM" src="https://github.com/PAIR-code/recommendation-rudders/assets/16089305/dffce830-f4f1-4eeb-8132-e74cb0415292">

TODO: 
- actually disabled editing in individual components when viewing results from past (completed) stages