### PR TITLE
Allow experiment deletion within the experiment monitoring component.

### DIFF
--- a/llm-meditators/webapp/src/app/experimenter-view/experiment-monitor/experiment-monitor.component.html
+++ b/llm-meditators/webapp/src/app/experimenter-view/experiment-monitor/experiment-monitor.component.html
@@ -52,3 +52,9 @@
     }
   </div>
 }
+
+<h2>Experiment settings:</h2>
+
+<button mat-raised-button color="warn" aria-label="Delete" (click)="deleteExperiment()">
+  <mat-icon>delete</mat-icon> Delete this experiment
+</button>

--- a/llm-meditators/webapp/src/app/experimenter-view/experiment-monitor/experiment-monitor.component.ts
+++ b/llm-meditators/webapp/src/app/experimenter-view/experiment-monitor/experiment-monitor.component.ts
@@ -1,7 +1,10 @@
 import { Component, Input, Signal, WritableSignal, computed, signal } from '@angular/core';
-import { RouterLink, RouterLinkActive, RouterModule } from '@angular/router';
+import { Router, RouterLink, RouterLinkActive, RouterModule } from '@angular/router';
 import { AppStateService } from 'src/app/services/app-state.service';
+import { deleteExperiment } from 'src/lib/staged-exp/app';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 
 import { StageKinds, UserData, UserProfile } from 'src/lib/staged-exp/data-model';
 import { MediatorChatComponent } from '../mediator-chat/mediator-chat.component';
@@ -18,7 +21,7 @@ export interface StageState {
 @Component({
   selector: 'app-experiment-monitor',
   standalone: true,
-  imports: [RouterModule, RouterLink, RouterLinkActive, MediatorChatComponent, MatExpansionModule],
+  imports: [RouterModule, RouterLink, RouterLinkActive, MediatorChatComponent, MatButtonModule, MatExpansionModule, MatIconModule],
   templateUrl: './experiment-monitor.component.html',
   styleUrl: './experiment-monitor.component.scss',
 })
@@ -37,7 +40,7 @@ export class ExperimentMonitorComponent {
   isOfKind = isOfKind;
   readonly StageKinds = StageKinds;
 
-  constructor(public stateService: AppStateService) {
+  constructor(public stateService: AppStateService, public router: Router) {
     this.participants = computed(() => {
       console.log('experimentName:', this.experimentName());
       if (!(this.experimentName() in this.stateService.data().experiments)) {
@@ -73,5 +76,16 @@ export class ExperimentMonitorComponent {
       });
       return stageStates;
     });
+  }
+
+  deleteExperiment() {
+    if (confirm("⚠️ This will delete the experiment! Are you sure?")) {
+      this.stateService.editData((data) =>
+        deleteExperiment(this.experimentName(), data),
+      );
+      
+      // Redirect to settings page.
+      this.router.navigate(['/experimenter', 'settings']);
+    }
   }
 }

--- a/llm-meditators/webapp/src/lib/staged-exp/app.ts
+++ b/llm-meditators/webapp/src/lib/staged-exp/app.ts
@@ -159,6 +159,15 @@ export function addExperiment(name: string, stages: ExpStage[], appData: SavedAp
   appData.experiments[experiment.name] = experiment;
 }
 
+export function deleteExperiment(name: string, appData: SavedAppData) {
+  if (name in appData.experiments) {
+    delete appData.experiments[name];
+  } else {
+    console.log(
+      "Experiment " + name + " is not found: " + appData.experiments);
+  }
+}
+
 // export function initialAppData(): SavedAppData {
 //   const experiment = initialExperimentSetup(3);
 //   const experiments: { [name: string]: Experiment } = {};


### PR DESCRIPTION
This adds a "Delete experiment" button to each experiment monitoring page. Upon click (and pop-up confirmation), the experiment is deleted and the user is rerouted to the Settings page.
